### PR TITLE
Add Esbonio language server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
-    "restructuredtext.builtDocumentationPath": "${workspaceFolder}/build/html",
-    "restructuredtext.confPath": "${workspaceFolder}/docs",
     "vale.core.useCLI": true,
     "gitlens.showWelcomeOnInstall": false,
-    "vale.valeCLI.path": "/sphinx-tools/vale/vale"
+    "vale.valeCLI.path": "/sphinx-tools/vale/vale",
+    "esbonio.sphinx.buildDir": "${workspaceFolder}/build",
+    "esbonio.sphinx.confDir": "${workspaceFolder}/docs",
+    "restructuredtext.pythonRecommendation.disabled": true
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,5 @@
 sphinx==4.4.0
 sphinx_rtd_theme==1.0.0
 readthedocs-sphinx-search==0.1.1
-snooty-lextudio==1.12.0
 rstcheck==3.3.1
 esbonio==0.10.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ sphinx_rtd_theme==1.0.0
 readthedocs-sphinx-search==0.1.1
 snooty-lextudio==1.12.0
 rstcheck==3.3.1
+esbonio==0.10.2


### PR DESCRIPTION
The `reStructuredText` VS Code extension is switching to [Esbonio](https://github.com/swyddfa/esbonio#what-about-the-restructuredtext-extension) since v171.0.0 which has various [benefits](https://github.com/vscode-restructuredtext/vscode-restructuredtext/issues/348). When opening the workspace in Gitpod, a bunch of recommendations are now showing up to migrate settings accordingly.

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/24"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

