### PR TITLE
Docs of several components (extending Mautic)

### DIFF
--- a/docs/components/api.rst
+++ b/docs/components/api.rst
@@ -1,7 +1,7 @@
 API
 ==========================================================
 
-To add custom API endpoints, simply define the routes under the API firewall in the :doc:`Plugin's config file</plugins/config>`.
+To add custom API endpoints, define the routes under the API firewall in the :doc:`Plugin's config file</plugins/config>`.
 This places the route behind ``/api`` which is only accessible to authorized Users.
 
 .. code-block:: php

--- a/docs/components/api.rst
+++ b/docs/components/api.rst
@@ -1,4 +1,99 @@
 API
 ==========================================================
 
+To add custom API endpoints, simply define the routes under the API firewall in the :doc:`Plugin's config file</plugins/config>`.
+This places the route behind ``/api`` which is only accessible to authorized Users.
 
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Config/config.php
+
+    declare(strict_types=1);
+
+    return [
+        // ...
+
+        'services' => [
+
+            // ...
+
+            'controllers' => [
+                'plugin.hello_world.controller.api' => [
+                    'class' => \MauticPlugin\HelloWorldBundle\Controller\ApiController::class,
+                    'arguments' => [
+                        'mautic.security',
+                        'plugin.hello_world.model.worlds'
+                    ],
+                    'methodCalls' => [
+                        'setContainer' => [
+                            '@service_container',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+
+        'routes'   => [
+
+            // ...
+
+            'api' => [
+                'plugin_helloworld_api' => [
+                    'path'       => '/hello/worlds',
+                    'controller' => 'HelloWorldBundle:Api:worlds',
+                    'method'     => 'GET'
+                ]
+            ]
+        ],
+
+        // ...
+    ];
+
+The API controller should extend ``Mautic\ApiBundle\Controller\CommonApiController`` to leverage the helper methods provided.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Controller/ApiController.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\Controller;
+
+    use Mautic\ApiBundle\Controller\CommonApiController;
+    use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+    use MauticPlugin\HelloWorldBundle\Model\WorldsModel;
+    use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\Response;
+
+    class ApiController extends CommonApiController
+    {
+        private CorePermissions $corePermissions;
+        private WorldsModel     $worldsModel;
+
+        public function __construct(CorePermissions $corePermissions, WorldsModel $worldsModel)
+        {
+            $this->corePermissions = $corePermissions;
+            $this->worldsModel     = $worldsModel;
+        }
+        
+        /**
+        * Get a list of worlds
+        */
+        public function getWorldsAction(Request $request): Response
+        {
+            if (!$this->corePermissions->isGranted('plugin:helloWorld:worlds:view')) {
+                return $this->accessDenied();
+            }
+
+            $filter  = $request->query->get('filter', null);
+            $limit   = $request->query->get('limit', null);
+            $start   = $request->query->get('start', null);
+
+            $worlds  = $this->model->getWorlds($filter, $limit, $start);
+            $worlds  = $this->view($worlds, 200);
+
+            return $this->handleView($worlds);
+        }
+    }

--- a/docs/components/categories.rst
+++ b/docs/components/categories.rst
@@ -64,10 +64,10 @@ Restricting Category Management
 
 .. vale on
 
-To restrict access to Categories, use the following in the Plugin's Permission class (TODO).
+To restrict access to Categories, use the following in the Plugin's :ref:`Permission class<security-roles-and-permissions>`.
 
 In ``__construct()``, add ``$this->addStandardPermissions('categories');``, then in ``buildForm()``, add ``$this->addStandardFormFields('helloWorld', 'categories', $builder, $data);``.
 
-See a code example in Roles and Permissions (TODO).
+See a code example in :ref:`Roles and Permissions<security-roles-and-permissions>`.
 
 The two standard helper methods add the permissions of ``view``, ``edit``, ``create``, ``delete``, ``publish``, and ``full`` for Categories.

--- a/docs/components/categories.rst
+++ b/docs/components/categories.rst
@@ -21,7 +21,7 @@ You can add Categories through your Plugin's ``config.php`` file by adding the f
         'plugin:helloWorld' => 'mautic.helloworld.world.categories'
     ]
 
-Please prefix Category keys with ``plugin:`` it determines permissions to manage Categories.
+Please prefix Category keys with ``plugin:`` as it determines permissions to manage Categories.
 The ``helloWorld`` should match the permission class name.
 
 .. vale off

--- a/docs/components/categories.rst
+++ b/docs/components/categories.rst
@@ -31,8 +31,7 @@ Configuring Categories for Routes
 
 .. vale on
 
-There is no need to add custom routes for Categories.
-However, when generating a URL to the Plugin's Category list, use the following code:
+There is no need to add custom routes for Categories, however, when generating a URL to the Plugin's Category list, use the following code:
 
 .. code-block:: php
     

--- a/docs/components/categories.rst
+++ b/docs/components/categories.rst
@@ -42,7 +42,7 @@ However, when generating a URL to the Plugin's Category list, use the following 
 
 .. vale off
 
-Including Category in Forms
+Including Categories in Forms
 ---------------------------
 
 .. vale on

--- a/docs/components/categories.rst
+++ b/docs/components/categories.rst
@@ -1,4 +1,57 @@
 Categories
 ==========================================================
 
+Categories are a way to organize Mautic elements.
+Mautic has a ``CategoryBundle`` that you can leverage to incorporate Categories into your Plugin.
 
+Adding Categories
+-----------------
+
+You can add Categories through your Plugin's ``config.php`` file by adding the following as a key to the returned config array:
+
+.. code-block:: php
+
+    <?php
+
+    'categories' => [
+        'plugin:helloWorld' => 'mautic.helloworld.world.categories'
+    ]
+
+Please prefix Category keys with ``plugin:`` it determines permissions to manage Categories.
+The ``helloWorld`` should match the permission class name.
+
+Configuring Categories for Routes
+---------------------------------
+
+There is no need to add custom routes for Categories.
+However, when generating a URL to the Plugin's Category list, use the following code:
+
+.. code-block:: php
+    
+    <?php
+
+    $categoryUrl = $router->generateUrl('mautic_category_index', ['bundle' => 'plugin:helloWorld']);
+
+Including Category in Forms
+---------------------------
+
+To add a Category select list to a Form, use ``category`` as the Form type and pass ``bundle`` as an option:
+
+.. code-block:: php
+
+    <?php
+    
+    $builder->add('category', 'category', [
+        'bundle' => 'plugin:helloWorld'
+    ]);
+
+Restricting Category Management
+-------------------------------
+
+To restrict access to Categories, use the following in the Plugin's Permission class (TODO).
+
+In ``__construct()``, add ``$this->addStandardPermissions('categories');``, then in ``buildForm()``, add ``$this->addStandardFormFields('helloWorld', 'categories', $builder, $data);``.
+
+See a code example in Roles and Permissions (TODO).
+
+The two standard helper methods add the permissions of ``view``, ``edit``, ``create``, ``delete``, ``publish``, and ``full`` for Categories.

--- a/docs/components/categories.rst
+++ b/docs/components/categories.rst
@@ -4,8 +4,12 @@ Categories
 Categories are a way to organize Mautic elements.
 Mautic has a ``CategoryBundle`` that you can leverage to incorporate Categories into your Plugin.
 
+.. vale off
+
 Adding Categories
 -----------------
+
+.. vale on
 
 You can add Categories through your Plugin's ``config.php`` file by adding the following as a key to the returned config array:
 
@@ -20,8 +24,12 @@ You can add Categories through your Plugin's ``config.php`` file by adding the f
 Please prefix Category keys with ``plugin:`` it determines permissions to manage Categories.
 The ``helloWorld`` should match the permission class name.
 
+.. vale off
+
 Configuring Categories for Routes
 ---------------------------------
+
+.. vale on
 
 There is no need to add custom routes for Categories.
 However, when generating a URL to the Plugin's Category list, use the following code:
@@ -32,8 +40,12 @@ However, when generating a URL to the Plugin's Category list, use the following 
 
     $categoryUrl = $router->generateUrl('mautic_category_index', ['bundle' => 'plugin:helloWorld']);
 
+.. vale off
+
 Including Category in Forms
 ---------------------------
+
+.. vale on
 
 To add a Category select list to a Form, use ``category`` as the Form type and pass ``bundle`` as an option:
 
@@ -45,8 +57,12 @@ To add a Category select list to a Form, use ``category`` as the Form type and p
         'bundle' => 'plugin:helloWorld'
     ]);
 
+.. vale off
+
 Restricting Category Management
 -------------------------------
+
+.. vale on
 
 To restrict access to Categories, use the following in the Plugin's Permission class (TODO).
 

--- a/docs/components/channels.rst
+++ b/docs/components/channels.rst
@@ -67,7 +67,7 @@ The event listener should check for the appropriate context and ID.
     use MauticPlugin\HelloWorldPlugin\Model\WorldModel;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-    class BroadcastSubscriber implements EventSubscriberInterface
+    final class BroadcastSubscriber implements EventSubscriberInterface
     {
         private WorldModel $model;
 
@@ -76,14 +76,14 @@ The event listener should check for the appropriate context and ID.
             $this->model = $model;
         }
 
-        public static function getSubscribedEvents()
+        public static function getSubscribedEvents(): array
         {
             return [
                 ChannelEvents::CHANNEL_BROADCAST => ['onChannelBroadcast', 0]
             ];
         }
 
-        public function onChannelBroadcast(ChannelBroadcastEvent $event)
+        public function onChannelBroadcast(ChannelBroadcastEvent $event): void
         {
             if (!$event->checkContext('world')) {
                 return;

--- a/docs/components/channels.rst
+++ b/docs/components/channels.rst
@@ -1,10 +1,14 @@
 Channels
 ==========================================================
+
 Todo:
 
 Preference center integration
 
-How to register Channel features:
+Listening for channel features
+------------------------------
+
+You can find several events through the ``ChannelEvents`` class.
 
 .. code-block:: php
 
@@ -38,4 +42,61 @@ How to register Channel features:
                 ],
             ]
         );
+    }
+
+Extending broadcasts
+--------------------
+
+Broadcasts are communications sent in bulk through a Channel such as Email.
+An event is available to execute the sending of these bulk communications via the ``mautic:broadcasts:send`` command.
+
+To hook into the ``mautic:broadcasts:send`` command, create a listener for the ``\Mautic\CoreBundle\CoreEvents::CHANNEL_BROADCAST`` event.
+The event listener should check for the appropriate context and ID.
+
+.. code-block:: php
+
+    <?php
+    // plugins\HelloWorldBundle\EventListener\BroadcastSubscriber
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\ChannelBundle\ChannelEvents;
+    use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
+    use MauticPlugin\HelloWorldPlugin\Model\WorldModel;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class BroadcastSubscriber implements EventSubscriberInterface
+    {
+        private WorldModel $model;
+
+        public function __construct(WorldModel $model)
+        {
+            $this->model = $model;
+        }
+
+        public static function getSubscribedEvents()
+        {
+            return [
+                ChannelEvents::CHANNEL_BROADCAST => ['onChannelBroadcast', 0]
+            ];
+        }
+
+        public function onChannelBroadcast(ChannelBroadcastEvent $event)
+        {
+            if (!$event->checkContext('world')) {
+                return;
+            }
+
+            // Get list of published broadcasts or broadcast if there is only a single ID
+            $id         = $event->getId();
+            $broadcasts = $this->model->getRepository()->getPublishedBroadcasts($id);
+            $output     = $event->getOutput();
+
+            while (($broadcast = $broadcasts->next()) !== false) {
+                list($sentCount, $failedCount, $ignore) = $this->model->sendIntergalacticMessages($broadcast[0], null, 100, true, $output);
+                $event->setResults($this->translator->trans('plugin.helloworld').': '.$broadcast[0]->getName(), $sentCount, $failedCount);
+            }
+        }
     }

--- a/docs/components/channels.rst
+++ b/docs/components/channels.rst
@@ -1,12 +1,12 @@
 Channels
 ==========================================================
 
-Todo:
+.. vale off
 
-Preference center integration
-
-Listening for channel features
+Listening for Channel features
 ------------------------------
+
+.. vale on
 
 You can find several events through the ``ChannelEvents`` class.
 

--- a/docs/components/contacts.rst
+++ b/docs/components/contacts.rst
@@ -12,7 +12,7 @@ Using this event, the plugin can inject unique items into the timeline and also 
 
 .. note:: Before using this event listener, you'll need to ensure that you store your custom events in a custom database table. See :ref:`Generating timeline events from your own custom events` below for more details.
 
-The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` object. The commonly used methods are defined below:
+The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` object. You can find the commonly used methods below the code example.
 
 .. code-block:: PHP
 
@@ -125,11 +125,11 @@ The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` obje
     * - ``addEventType()``
       - Required - Add this event to the list of available events.
     * - ``getLead()``
-      - Get the Lead entity the event is dispatched for
+      - Get the Contact entity
     * - ``getQueryOptions()``
       - Used to get pagination, filters, etc needed to generate an appropriate query.
     * - ``addToCounter()``
-      - Used to add total number of events (across all pages) to the counters. This also generates the numbers for the engagements graph.
+      - Used to add total number of events across all Pages to the counters. This also generates the numbers for the engagements graph.
     * - ``addEvent()``
       - Required - Injects an event into the timeline. Accepts an array with the keys defined as below. 
 
@@ -155,15 +155,15 @@ The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` obje
     * - ``eventLabel``
       - Optional
       - string/array
-      - The translated string to display in the event name. Examples include names of items, page titles, etc. This can also be an array of ['label' => '', 'href' => ''] to have the entry converted to a link. This will default to eventType if not defined.
+      - The translated string to display in the event name. Examples include names of items, Landing Page titles, etc. This can also be an array of ['label' => '', 'href' => ''] to have the entry converted to a link. This defaults to eventType if not defined.
     * - ``extra``
       - Optional
       - array
-      - Whatever should be passed through to the content template to generate the details view for this event
+      - Anything you want to pass through to the content template to generate the details view for this event
     * - ``contentTemplate``
       - Optional
       - string
-      - Template that should be used to generate the details view for this event. Eg. ``HelloBundle:SubscribedEvents\Timeline:index.html.php``
+      - Template you want to use to generate the details view for this event. Eg. ``HelloBundle:SubscribedEvents\Timeline:index.html.php``
     * - ``icon``
       - Optional
       - Font Awesome class
@@ -230,28 +230,28 @@ To leverage this, accept the array from ``$event->getQueryOptions()`` in the rep
     * - $query
       - Required
       - QueryBuilder
-      - DBAL QueryBuilder object defining basics of the query.
+      - Database Abstraction Layer QueryBuilder object defining basics of the query.
     * - $options
       - Required
       - array
-      - Array generated and passed into method by $event->getQueryOptions() in the event listener above
+      - Array generated and passed into method by ``$event->getQueryOptions()`` in the event listener above
     * - $eventNameColumn
       - Required
       - string
-      - Name of the column (with table prefix) that should be used when sorting by event name
+      - Name of the column with table prefix that should to use when sorting by event name
     * - $timestampColumn
       - Required
       - string
-      - Name of the column (with table prefix) that should be used when sorting by timestamp
+      - Name of the column with table prefix that should to use when sorting by timestamp
     * - $serializedColumns
       - Optional
       - array
-      - When using DBAL, arrays are not auto-unserialized by Doctrine. Define the columns here (as returned by the query results) to auto-unserialize.
+      - When using the Database Abstraction Layer, arrays won't be auto-unserialized by Doctrine. Define the columns here, as returned by the query results, to auto-unserialize.
     * - $dateTimeColumns
       - Optional
       - array
-      - When using DBAL, ``datetime`` columns are not auto converted to \DateTime objects by Doctrine. Define the columns here (as returned by the query results) to auto do so.
+      - When using the Database Abstraction Layer, ``datetime`` columns won't be auto converted to \DateTime objects by Doctrine. Define the columns here, as returned by the query results, to auto do so.
     * - $resultsParserCallback
       - Optional
       - callback
-      - Callback to custom parse a result. This is optional and mainly used to handle a column result when all results are already being looped over for $serializedColumns and $dateTimeColumns.
+      - Callback to custom parse a result. This is optional and mainly used to handle a column result when all results are already looped over for $serializedColumns and $dateTimeColumns.

--- a/docs/components/contacts.rst
+++ b/docs/components/contacts.rst
@@ -8,7 +8,7 @@ Contact timeline/history
 ------------------------
 
 To inject events into a Contact's timeline, create an event listener that listens to the ``LeadEvents::TIMELINE_ON_GENERATE`` event.
-Using this event, the plugin can inject unique items into the timeline and also into the engagements graph on each page.
+Using this event, the Plugin can inject unique items into the timeline and also into the engagements graph on each page.
 
 .. note:: Before using this event listener, you'll need to ensure that you store your custom events in a custom database table. See :ref:`Generating timeline events from your own custom events` below for more details.
 

--- a/docs/components/contacts.rst
+++ b/docs/components/contacts.rst
@@ -1,4 +1,257 @@
 Contacts
 ==========================================================
 
+There's several ways to extend Contacts in Mautic.
+One of them is to show custom events in a Contact's event timeline - this document shows you how.
 
+Contact timeline/history
+------------------------
+
+To inject events into a Contact's timeline, create an event listener that listens to the ``LeadEvents::TIMELINE_ON_GENERATE`` event.
+Using this event, the plugin can inject unique items into the timeline and also into the engagements graph on each page.
+
+.. note:: Before using this event listener, you'll need to ensure that you store your custom events in a custom database table. See :ref:`Generating timeline events from your own custom events` below for more details.
+
+The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` object. The commonly used methods are defined below:
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/LeadSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Doctrine\ORM\EntityManager;
+    use Mautic\LeadBundle\Event\LeadTimelineEvent;
+    use Mautic\LeadBundle\LeadEvents;
+    use MauticPlugin\HelloWorldBundle\Entity\WorldRepository;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\Routing\RouterInterface;
+    use Symfony\Contracts\Translation\TranslatorInterface;
+
+    class LeadSubscriber implements EventSubscriberInterface
+    {
+        private TranslatorInterface $translator;
+        private EntityManager $em;
+        private RouterInterface $router;
+
+        public function __construct(TranslatorInterface $translator, EntityManager $em, RouterInterface $router)
+        {
+            $this->translator = $translator;
+            $this->em         = $em;
+            $this->router     = $router;
+        }
+
+        public static function getSubscribedEvents()
+        {
+            return [
+                LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0]
+            ];
+        }
+
+        public function onTimelineGenerate(LeadTimelineEvent $event): void
+        {
+            // Add this event to the list of available events which generates the event type filters
+            $eventTypeKey  = 'visited.worlds';
+            $eventTypeName = $this->translator->trans('mautic.hello.world.visited_worlds');
+            $event->addEventType($eventTypeKey, $eventTypeName);
+
+            // Determine if this event has been filtered out
+            if (!$event->isApplicable($eventTypeKey)) {
+                return;
+            }
+
+            /** @var WorldRepository */
+            $repository = $this->em->getRepository(WorldRepository::class);
+
+            // $event->getQueryOptions() provide timeline filters, etc.
+            // This method should use DBAL to obtain the events to be injected into the timeline based on pagination
+            // but also should query for a total number of events and return an array of ['total' => $x, 'results' => []].
+            // There is a TimelineTrait to assist with this. See repository example.
+            $stats = $repository->getTimelineStats($event->getLead()->getId(), $event->getQueryOptions());
+
+            // If isEngagementCount(), this event should only inject $stats into addToCounter() to append to data to generate
+            // the engagements graph. Not all events are engagements if they are just informational so it could be that this
+            // line should only be used when `!$event->isEngagementCount()`. Using TimelineTrait will determine the appropriate
+            // return value based on the data included in getQueryOptions() if used in the stats method above.
+            $event->addToCounter($eventTypeKey, $stats);
+
+            if (!$event->isEngagementCount()) {
+                // Add the events to the event array
+                foreach ($stats['results'] as $stat) {
+                    if ($stat['dateSent']) {
+                        $event->addEvent(
+                            [
+                                // Event key type
+                                'event'           => $eventTypeKey,
+                                // Event name/label - can be a string or an array as below to convert to a link
+                                'eventLabel'      => [
+                                    'label' => $stat['name'],
+                                    'href'  => $this->router->generate(
+                                        'mautic_dynamicContent_action',
+                                        ['objectId' => $stat['dynamic_content_id'], 'objectAction' => 'view']
+                                    )
+                                ],
+                                // Translated string displayed in the Event Type column
+                                'eventType'       => $eventTypeName,
+                                // \DateTime object for the timestamp column
+                                'timestamp'       => $stat['dateSent'],
+                                // Optional details passed through to the contentTemplate
+                                'extra'           => [
+                                    'stat' => $stat,
+                                    'type' => 'sent'
+                                ],
+                                // Optional template to customize the details of the event in the timeline
+                                'contentTemplate' => 'MauticDynamicContentBundle:SubscribedEvents\Timeline:index.html.php',
+                                // Font Awesome class to display as the icon
+                                'icon'            => 'fa-envelope'
+                            ]
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+.. list-table::
+    :header-rows: 1
+
+    * - Method
+      - Description
+    * - ``isApplicable()``
+      - Determines if this event is applicable and not filtered out.
+    * - ``addEventType()``
+      - Required - Add this event to the list of available events.
+    * - ``getLead()``
+      - Get the Lead entity the event is dispatched for
+    * - ``getQueryOptions()``
+      - Used to get pagination, filters, etc needed to generate an appropriate query.
+    * - ``addToCounter()``
+      - Used to add total number of events (across all pages) to the counters. This also generates the numbers for the engagements graph.
+    * - ``addEvent()``
+      - Required - Injects an event into the timeline. Accepts an array with the keys defined as below. 
+
+.. list-table::
+    :header-rows: 1
+
+    * - Key
+      - Required
+      - Type
+      - Description
+    * - ``event``
+      - Required
+      - string
+      - The key for this event. Eg. world.visited
+    * - ``eventType``
+      - Required
+      - string
+      - The translated string representing this event type. Eg. Worlds visited
+    * - ``timestamp``
+      - Required
+      - \DateTime
+      - DateTime object when this event took place
+    * - ``eventLabel``
+      - Optional
+      - string/array
+      - The translated string to display in the event name. Examples include names of items, page titles, etc. This can also be an array of ['label' => '', 'href' => ''] to have the entry converted to a link. This will default to eventType if not defined.
+    * - ``extra``
+      - Optional
+      - array
+      - Whatever should be passed through to the content template to generate the details view for this event
+    * - ``contentTemplate``
+      - Optional
+      - string
+      - Template that should be used to generate the details view for this event. Eg. ``HelloBundle:SubscribedEvents\Timeline:index.html.php``
+    * - ``icon``
+      - Optional
+      - Font Awesome class
+      - 
+
+Generating timeline events from your own custom events
+------------------------------------------------------
+
+You're responsible for creating your own events and store them in some database tables.
+From there, you can turn them into timeline events so they show up on the Contact's detail screen.
+To make this process a bit easier, the ``Mautic\LeadBundle\Entity\TimelineTrait`` trait is available.
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/Entity/WorldRepository.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\Entity;
+
+    use Mautic\CoreBundle\Entity\CommonRepository;
+    use Mautic\LeadBundle\Entity\TimelineTrait;
+
+    /**
+    * @extends CommonRepository<World>
+    */
+    class WorldRepository extends CommonRepository
+    {
+        use TimelineTrait;
+
+        /**
+        * @param array<string,string> $options
+        * @return array<string,mixed>
+        */
+        public function getTimelineStats(int $leadId, array $options = []): array
+        {
+            $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+            $query->select('w.id, w.name, w.visited_count, w.date_visited, w.visit_details')
+                ->from(MAUTIC_TABLE_PREFIX . 'world_visits', 'w')
+                ->where($query->expr()->eq('w.lead_id', (int) $leadId));
+
+            if (isset($options['search']) && $options['search']) {
+                $query->andWhere(
+                    $query->expr()->like('w.name', $query->expr()->literal('%' . $options['search'] . '%'))
+                );
+            }
+
+            return $this->getTimelineResults($query, $options, 'w.name', 'w.date_visited', ['visit_details'], ['date_visited']);
+        }
+    }
+
+
+To leverage this, accept the array from ``$event->getQueryOptions()`` in the repository method. Create a DBAL QueryBuilder object (``$this->getEntityManager()->getConnection()->createQueryBuilder()``) and define the basics of the array, including filtering by lead id and search filter. Then pass the QueryBuilder object to the ``getTimelineResults()`` method along with the following arguments:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Key
+      - Required
+      - Type
+      - Description
+    * - $query
+      - Required
+      - QueryBuilder
+      - DBAL QueryBuilder object defining basics of the query.
+    * - $options
+      - Required
+      - array
+      - Array generated and passed into method by $event->getQueryOptions() in the event listener above
+    * - $eventNameColumn
+      - Required
+      - string
+      - Name of the column (with table prefix) that should be used when sorting by event name
+    * - $timestampColumn
+      - Required
+      - string
+      - Name of the column (with table prefix) that should be used when sorting by timestamp
+    * - $serializedColumns
+      - Optional
+      - array
+      - When using DBAL, arrays are not auto-unserialized by Doctrine. Define the columns here (as returned by the query results) to auto-unserialize.
+    * - $dateTimeColumns
+      - Optional
+      - array
+      - When using DBAL, ``datetime`` columns are not auto converted to \DateTime objects by Doctrine. Define the columns here (as returned by the query results) to auto do so.
+    * - $resultsParserCallback
+      - Optional
+      - callback
+      - Callback to custom parse a result. This is optional and mainly used to handle a column result when all results are already being looped over for $serializedColumns and $dateTimeColumns.

--- a/docs/components/contacts.rst
+++ b/docs/components/contacts.rst
@@ -31,7 +31,7 @@ The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` obje
     use Symfony\Component\Routing\RouterInterface;
     use Symfony\Contracts\Translation\TranslatorInterface;
 
-    class LeadSubscriber implements EventSubscriberInterface
+    final class LeadSubscriber implements EventSubscriberInterface
     {
         private TranslatorInterface $translator;
         private EntityManager $em;
@@ -44,7 +44,7 @@ The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` obje
             $this->router     = $router;
         }
 
-        public static function getSubscribedEvents()
+        public static function getSubscribedEvents(): array
         {
             return [
                 LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0]

--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -1,12 +1,12 @@
 Emails
 ==========================================================
 
-There are multiple ways to extend the way Mautic works with Emails. This document describes the following options for extending Mautic's email functionality:
+There are multiple ways to extend the way Mautic works with Emails. This document describes the following options for extending Mautic's Email capabilities:
 
 - Email tokens
 - A/B testing
 - Monitored Inbox Integration
-- Email transport (email providers)
+- Email transport/Email providers
 - Email stat helpers
 
 Email tokens and A/B testing
@@ -18,12 +18,12 @@ They get replaced by dynamic content once the Email gets sent or viewed in the b
 You can find examples of both Email token handling and A/B testing in the code example below.
 Both leverage the ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_BUILD`` event. Read more about listeners and subscribers (TODO add link).
 
-Email token capabilities consist of two parts: registering your custom token(s) and rendering them.
+Email token capabilities consist of two parts: registering your custom tokens and rendering them.
 
 - ``$event->addToken($uniqueId, $htmlContent)`` allows you to show the email token in the email builder, so that users can easily add the token to their emails.
 - ``$event->getContent()`` and ``$event->setContent()`` are used for replacing the email token with actual dynamic content once the Email gets send or viewed in the browser.
 
-While Mautic supports A/B testing out of the box (https://kb.mautic.org/knowledgebase/emails/how-does-mautic-do-ab-testing), you might have more complex needs to determine A/B test winner criteria.
+While Mautic supports :xref:`A/B testing` out of the box, you might have more complex needs to determine A/B test winner criteria.
 
 - ``$event->addAbTestWinnerCriteria()`` allows you to do exactly that. Using your custom logic, you can decide the winner of such criteria. An example is shown below.
 - ``$event->setAbTestResults()`` is where you set the actual A/B test results. More details are in the code example below.
@@ -179,8 +179,12 @@ While Mautic supports A/B testing out of the box (https://kb.mautic.org/knowledg
         ); ?>
     </div>
 
+.. vale off
+
 Monitored Inbox Integration
 ---------------------------
+
+.. vale on
 
 Plugins have access to hook into the ``mautic:email:fetch`` command to fetch email from a specific inbox/folder and process the content of the message.
 The Plugin also has access to inject specific search criteria for the messages to be processed.

--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -16,7 +16,7 @@ Email tokens are placeholders that you can insert into an Email.
 They get replaced by Dynamic Content once the Email gets sent or viewed in the browser.
 
 You can find examples of both Email token handling and A/B testing in the code example below.
-Both leverage the ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_BUILD`` event. Read more about listeners and subscribers (TODO add link).
+Both leverage the ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_BUILD`` event. Read more about :doc:`listeners and subscribers</plugins/event_listeners>`.
 
 Email token capabilities consist of two parts: registering your custom tokens and rendering them.
 

--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -1,13 +1,430 @@
 Emails
 ==========================================================
 
+There are multiple ways to extend the way Mautic works with Emails. This document describes the following options for extending Mautic's email functionality:
+
+- Email tokens
+- A/B testing
+- Monitored Inbox Integration
+- Email transport (email providers)
+- Email stat helpers
+
+Email tokens and A/B testing
+----------------------------
+
+Email tokens are placeholders that you can insert into an Email.
+They get replaced by dynamic content once the Email gets sent or viewed in the browser.
+
+You can find examples of both Email token handling and A/B testing in the code example below.
+Both leverage the ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_BUILD`` event. Read more about listeners and subscribers (TODO add link).
+
+Email token capabilities consist of two parts: registering your custom token(s) and rendering them.
+
+- ``$event->addToken($uniqueId, $htmlContent)`` allows you to show the email token in the email builder, so that users can easily add the token to their emails.
+- ``$event->getContent()`` and ``$event->setContent()`` are used for replacing the email token with actual dynamic content once the Email gets send or viewed in the browser.
+
+While Mautic supports A/B testing out of the box (https://kb.mautic.org/knowledgebase/emails/how-does-mautic-do-ab-testing), you might have more complex needs to determine A/B test winner criteria.
+
+- ``$event->addAbTestWinnerCriteria()`` allows you to do exactly that. Using your custom logic, you can decide the winner of such criteria. An example is shown below.
+- ``$event->setAbTestResults()`` is where you set the actual A/B test results. More details are in the code example below.
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/EmailSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\CoreBundle\Helper\TemplatingHelper;
+    use Mautic\EmailBundle\EmailEvents;
+    use Mautic\EmailBundle\Event\EmailBuilderEvent;
+    use Mautic\EmailBundle\Event\EmailSendEvent;
+    use MauticPlugin\HelloWorldBundle\HelloWorldEvents;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class EmailSubscriber implements EventSubscriberInterface
+    {
+        private TemplatingHelper $templating;
+
+        public function __construct(TemplatingHelper $templating)
+        {
+            $this->templating = $templating;
+        }
+
+        public static function getSubscribedEvents()
+        {
+            return array(
+                EmailEvents::EMAIL_ON_BUILD   => array('onEmailBuild', 0),
+                EmailEvents::EMAIL_ON_SEND    => array('onEmailGenerate', 0),
+                EmailEvents::EMAIL_ON_DISPLAY => array('onEmailGenerate', 0)
+            );
+        }
+
+        /**
+        * Register the token and a custom A/B test winner
+        */
+        public function onEmailBuild(EmailBuilderEvent $event): void
+        {
+            // Displays the token in the email builder, so that users can easily find it and add it to their emails
+            $event->addToken('helloworld.token', 'Hello world token');
+
+            // Add AB Test Winner Criteria
+            $event->addAbTestWinnerCriteria(
+                'helloworld.planetvisits',
+                [
+                    // Label to group by
+                    'group' => 'plugin.helloworld.header',
+                    
+                    // Label for this specific a/b test winning criteria
+                    'label' => 'plugin.helloworld.emailtokens.',
+
+                    // Event that will be used to determine the winner
+                    'event' => HelloWorldEvents::ON_DETERMINE_PLANET_VISIT_WINNER
+                ]
+            );
+        }
+
+        /**
+        * Search and replace tokens with content
+        */
+        public function onEmailGenerate(EmailSendEvent $event): void
+        {
+            // Get content
+            $content = $event->getContent();
+
+            // Search and replace tokens
+            $content = str_replace(
+                '{helloworld.token}',
+                $this->templating->getTemplating()->render('HelloWorldBundle:SubscribedEvents\EmailToken:token.html.php'),
+                $content
+            );
+
+            // Set updated content
+            $event->setContent($content);
+        }
+    }
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/PlanetVisitSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\CoreBundle\Event\DetermineWinnerEvent;
+    use MauticPlugin\HelloWorldBundle\HelloWorldEvents;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class PlanetVisitSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents()
+        {
+            return [
+                HelloWorldEvents::ON_DETERMINE_PLANET_VISIT_WINNER   => ['onDeterminePlanetVisitWinner', 0],
+            ];
+        }
+
+        public function onDeterminePlanetVisitWinner(DetermineWinnerEvent $event): void {
+            $event->setAbTestResults([
+                'winners' => [],
+                'support' => [
+                    'labels' => ['label1', 'label2'],
+                    'data'   => [
+                        'label1' => [100,200],
+                        'label2' => [200,300]
+                    ],
+                    'step_width' => 10
+                ],
+                'supportTemplate' => 'HelloWorldBundle:SubscribedEvents\AbTest:bargraph.html.php'
+            ]);
+        }
+    }
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/Views/SubscribedEvents/AbTest/bargraph.html.php
+
+    declare(strict_types=1);
+
+    $support = $results['support'];
+    $label   = 'My chart label';
+    $chart   = new \Mautic\CoreBundle\Helper\Chart\BarChart($support['labels']);
+
+    if ($support['data']) {
+        foreach ($support['data'] as $datasetLabel => $values) {
+            $chart->setDataset($datasetLabel, $values);
+        }
+    }
+    ?>
+
+    <div class="panel ovf-h bg-auto bg-light-xs abtest-bar-chart">
+        <div class="panel-body box-layout">
+            <div class="col-xs-8 va-m">
+                <h5 class="text-white dark-md fw-sb mb-xs">
+                    <?php echo $label; ?>
+                </h5>
+            </div>
+            <div class="col-xs-4 va-t text-right">
+                <h3 class="text-white dark-sm"><span class="fa fa-bar-chart"></span></h3>
+            </div>
+        </div>
+        <?php echo $view->render(
+            'MauticCoreBundle:Helper:chart.html.php',
+            ['chartData' => $chart->render(), 'chartType' => 'bar', 'chartHeight' => 300]
+        ); ?>
+    </div>
+
+Monitored Inbox Integration
+---------------------------
+
+Plugins have access to hook into the ``mautic:email:fetch`` command to fetch email from a specific inbox/folder and process the content of the message.
+The Plugin also has access to inject specific search criteria for the messages to be processed.
+
+To do this, the Plugin needs to add an event listener for three events:
+
+1. ``EmailEvents::MONITORED_EMAIL_CONFIG`` This event is dispatched to inject the fields into Mautic's Configuration to configure the IMAP inbox and folder that should be monitored.
+2. ``EmailEvents::EMAIL_PRE_FETCH`` This event is dispatched during the execution of the ``mautic:email:fetch`` command. It's used to inject search criteria for the messages desired.
+3. ``EmailEvents::EMAIL_PARSE`` This event parses the messages fetched by the command.
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/MonitoredInboxSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\EmailBundle\EmailEvents;
+    use Mautic\EmailBundle\Event\MonitoredEmailEvent;
+    use Mautic\EmailBundle\Event\ParseEmailEvent;
+    use Mautic\EmailBundle\MonitoredEmail\Mailbox;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class MonitoredInboxSubscriber implements EventSubscriberInterface
+    {
+        private $bundle = 'HelloWorldBundle';
+        private $monitor =  'deep_space_emails';
+
+        static public function getSubscribedEvents(): array
+        {
+            return [
+                EmailEvents::MONITORED_EMAIL_CONFIG => ['onConfig', 0],
+                EmailEvents::EMAIL_PRE_FETCH        => ['onPreFetch', 0],
+                EmailEvents::EMAIL_PARSE            => ['onParse', 0],
+            ];
+        }
+
+        /**
+        * Inject the IMAP folder settings into the Configuration
+        */
+        public function onConfig(MonitoredEmailEvent $event): void
+        {
+            /**
+            * The first argument is something unique to recognize this plugin.
+            * The second argument should be something unique to identify this monitored inbox.
+            * The third argument is the label for this monitored inbox.
+            */
+            $event->addFolder($this->bundle, $this->monitor, 'mautic.world.monitored_deep_space_emails');
+        }
+
+        /**
+        * Inject search criteria for which messages to fetch from the configured folder.
+        */
+        public function onPreFetch(ParseEmailEvent $event): void
+        {
+            $event->setCriteriaRequest($this->bundle, $this->monitor, Mailbox::CRITERIA_UNSEEN. " " . Mailbox::CRITERIA_FROM ." aliens@andromeda");
+        }
+
+        /**
+        * Parse the messages
+        */
+        public function onParse(ParseEmailEvent $event): void
+        {
+            if ($event->isApplicable($this->bundle, $this->monitor)) {
+                $messages = $event->getMessages();
+
+                foreach ($messages as $message) {
+                    // Do something
+                }
+            }
+        }
+    }
 
 Email transports
 ----------------------------
 
-todo see constants in ``\Mautic\EmailBundle\Model\TransportType``
+Mautic supports quite some Email providers out of the box (Amazon Simple Email Service, SendGrid, etc.).
+If you want to add your own Email transport, that's certainly possible.
+
+The most important thing here is to create a service that's tagged as ``mautic.email.transport_type``, so that Mautic recognizes it as a transport type.
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/Config/config.php
+
+    declare(strict_types=1);
+
+    return [
+        
+        ...
+
+        'services'    => [
+            
+            ...
+
+            'other' => [
+                'mautic.transport.helloworld_api' => [
+                    'class'        => \MauticPlugin\HelloWorldBundle\Swiftmailer\Transport\HelloWorldApiTransport::class,
+                    'serviceAlias' => 'swiftmailer.mailer.transport.%s',
+                    'arguments'    => [
+                        'mautic.helper.core_parameters',
+                    ],
+                    'tag'          => 'mautic.email_transport',
+                    'tagArguments' => [
+                        # Translatable alias that is used as an internal key for the transport type, but also as the translation key.
+                        \Mautic\EmailBundle\Model\TransportType::TRANSPORT_ALIAS => 'mautic.email.config.mailer_transport.helloworld_api',
+                        # Determines which fields to show in Mautic's configuration screen (under Email Settings)
+                        \Mautic\EmailBundle\Model\TransportType::FIELD_HOST      => true,
+                        \Mautic\EmailBundle\Model\TransportType::FIELD_API_KEY   => true,
+                        \Mautic\EmailBundle\Model\TransportType::FIELD_PASSWORD  => true,
+                        \Mautic\EmailBundle\Model\TransportType::FIELD_PORT      => true,
+                        \Mautic\EmailBundle\Model\TransportType::FIELD_USER      => true
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+The actual implementation of the service would then look something like this:
+
+.. code-block:: PHP
+
+    <?php
+    // plugin/HelloWorldBundle/Swiftmailer/Transport/HelloeWorldApiTransport.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\Swiftmailer\Transport;
+
+    use Mautic\CoreBundle\Helper\CoreParametersHelper;
+    use Mautic\EmailBundle\Swiftmailer\Transport\AbstractTokenArrayTransport;
+    use Mautic\EmailBundle\Swiftmailer\Transport\CallbackTransportInterface;
+    use Symfony\Component\HttpFoundation\Request;
+
+    class HelloWorldApiTransport extends AbstractTokenArrayTransport implements \Swift_Transport, CallbackTransportInterface
+    {
+        private CoreParametersHelper $coreParametersHelper;
+
+        public function __construct(CoreParametersHelper $coreParametersHelper)
+        {
+            $this->coreParametersHelper = $coreParametersHelper;
+        }
+
+        /**
+        * @return int
+        *
+        * @throws \Exception
+        */
+        public function send(\Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+        {
+            $count            = 0;
+            $failedRecipients = (array) $failedRecipients;
+
+            if ($event = $this->getDispatcher()->createSendEvent($this, $message)) {
+                $this->getDispatcher()->dispatchEvent($event, 'beforeSendPerformed');
+                if ($event->bubbleCancelled()) {
+                    return 0;
+                }
+            }
+
+            try {
+                // The message object contains all the email details (from/to/body/etc.)
+                $from = $message->getFrom();
+                $to   = $message->getTo();
+                $body = $message->getBody();
+
+                // Configuration values that were set by the user through Mautic's Configuration screen
+                $host   = $this->coreParametersHelper->get('mautic.mailer_host');
+                $apiKey = $this->coreParametersHelper->get('mautic.mailer_api_key');
+
+                // Do your magic for sending the email here
+                // $myService->send(...)
+
+                // Return the number of recipients who were accepted for delivery
+                return 1;
+            } catch (\Exception $e) {
+                $this->triggerSendError($event, $failedRecipients);
+                $message->generateId();
+                $this->throwException($e->getMessage());
+            }
+
+            // Return the number of recipients who were accepted for delivery
+            return 0;
+        }
+
+        /**
+        * @inheritdoc
+        */
+        public function getMaxBatchLimit(): int
+        {
+            return 50;
+        }
+
+        /**
+        * @inheritdoc
+        */
+        public function getBatchRecipientCount(\Swift_Message $message, $toBeAdded = 1, $type = 'to'): int
+        {
+            $toCount  = is_array($message->getTo()) ? count($message->getTo()) : 0;
+            $ccCount  = is_array($message->getCc()) ? count($message->getCc()) : 0;
+            $bccCount = is_array($message->getBcc()) ? count($message->getBcc()) : 0;
+
+            return null === $this->batchRecipientCount ? $this->batchRecipientCount : $toCount + $ccCount + $bccCount + $toBeAdded;
+        }
+
+        /**
+        * @inheritdoc
+        */
+        public function getCallbackPath(): string
+        {
+            return 'helloworld_api';
+        }
+
+        /**
+        * @inheritdoc
+        */
+        public function processCallbackRequest(Request $request)
+        {
+            $postData = json_decode($request->getContent(), true);
+
+            // Handle the callback here
+        }
+
+        private function triggerSendError(\Swift_Events_SendEvent $evt, array &$failedRecipients): void
+        {
+            $failedRecipients = array_merge(
+                $failedRecipients,
+                array_keys((array) $this->message->getTo()),
+                array_keys((array) $this->message->getCc()),
+                array_keys((array) $this->message->getBcc())
+            );
+
+            if ($evt) {
+                $evt->setResult(\Swift_Events_SendEvent::RESULT_FAILED);
+                $evt->setFailedRecipients($failedRecipients);
+                $this->getDispatcher()->dispatchEvent($evt, 'sendPerformed');
+            }
+        }
+    }
 
 Email stat helpers
------------------------
+------------------
 
-todo see  ``\Mautic\EmailBundle\Stats\Helper\StatHelperInterface``
+This section is in progress. See  ``\Mautic\EmailBundle\Stats\Helper\StatHelperInterface``

--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -13,7 +13,7 @@ Email tokens and A/B testing
 ----------------------------
 
 Email tokens are placeholders that you can insert into an Email.
-They get replaced by dynamic content once the Email gets sent or viewed in the browser.
+They get replaced by Dynamic Content once the Email gets sent or viewed in the browser.
 
 You can find examples of both Email token handling and A/B testing in the code example below.
 Both leverage the ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_BUILD`` event. Read more about listeners and subscribers (TODO add link).
@@ -21,7 +21,7 @@ Both leverage the ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_BUILD`` event. Rea
 Email token capabilities consist of two parts: registering your custom tokens and rendering them.
 
 - ``$event->addToken($uniqueId, $htmlContent)`` allows you to show the email token in the email builder, so that users can easily add the token to their emails.
-- ``$event->getContent()`` and ``$event->setContent()`` are used for replacing the email token with actual dynamic content once the Email gets send or viewed in the browser.
+- ``$event->getContent()`` and ``$event->setContent()`` are used for replacing the email token with actual Dynamic Content once the Email gets send or viewed in the browser.
 
 While Mautic supports :xref:`A/B testing` out of the box, you might have more complex needs to determine A/B test winner criteria.
 

--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -44,7 +44,7 @@ While Mautic supports :xref:`A/B testing` out of the box, you might have more co
     use MauticPlugin\HelloWorldBundle\HelloWorldEvents;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-    class EmailSubscriber implements EventSubscriberInterface
+    final class EmailSubscriber implements EventSubscriberInterface
     {
         private TemplatingHelper $templating;
 
@@ -53,13 +53,13 @@ While Mautic supports :xref:`A/B testing` out of the box, you might have more co
             $this->templating = $templating;
         }
 
-        public static function getSubscribedEvents()
+        public static function getSubscribedEvents(): array
         {
-            return array(
-                EmailEvents::EMAIL_ON_BUILD   => array('onEmailBuild', 0),
-                EmailEvents::EMAIL_ON_SEND    => array('onEmailGenerate', 0),
-                EmailEvents::EMAIL_ON_DISPLAY => array('onEmailGenerate', 0)
-            );
+            return [
+                EmailEvents::EMAIL_ON_BUILD   => ['onEmailBuild', 0],
+                EmailEvents::EMAIL_ON_SEND    => ['onEmailGenerate', 0],
+                EmailEvents::EMAIL_ON_DISPLAY => ['onEmailGenerate', 0],
+            ];
         }
 
         /**
@@ -119,16 +119,17 @@ While Mautic supports :xref:`A/B testing` out of the box, you might have more co
     use MauticPlugin\HelloWorldBundle\HelloWorldEvents;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-    class PlanetVisitSubscriber implements EventSubscriberInterface
+    final class PlanetVisitSubscriber implements EventSubscriberInterface
     {
-        public static function getSubscribedEvents()
+        public static function getSubscribedEvents(): array
         {
             return [
                 HelloWorldEvents::ON_DETERMINE_PLANET_VISIT_WINNER   => ['onDeterminePlanetVisitWinner', 0],
             ];
         }
 
-        public function onDeterminePlanetVisitWinner(DetermineWinnerEvent $event): void {
+        public function onDeterminePlanetVisitWinner(DetermineWinnerEvent $event): void
+        {
             $event->setAbTestResults([
                 'winners' => [],
                 'support' => [
@@ -210,7 +211,7 @@ To do this, the Plugin needs to add an event listener for three events:
     use Mautic\EmailBundle\MonitoredEmail\Mailbox;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-    class MonitoredInboxSubscriber implements EventSubscriberInterface
+    final class MonitoredInboxSubscriber implements EventSubscriberInterface
     {
         private $bundle = 'HelloWorldBundle';
         private $monitor =  'deep_space_emails';

--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -20,8 +20,8 @@ Both leverage the ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_BUILD`` event. Rea
 
 Email token capabilities consist of two parts: registering your custom tokens and rendering them.
 
-- ``$event->addToken($uniqueId, $htmlContent)`` allows you to show the email token in the email builder, so that users can easily add the token to their emails.
-- ``$event->getContent()`` and ``$event->setContent()`` are used for replacing the email token with actual Dynamic Content once the Email gets send or viewed in the browser.
+- ``$event->addToken($uniqueId, $htmlContent)`` allows you to show the Email token in the email builder, so that users can easily add the token to their emails.
+- ``$event->getContent()`` and ``$event->setContent()`` are used for replacing the Email token with actual Dynamic Content once the Email gets send or viewed in the browser.
 
 While Mautic supports :xref:`A/B testing` out of the box, you might have more complex needs to determine A/B test winner criteria.
 
@@ -187,7 +187,7 @@ Monitored Inbox Integration
 .. vale on
 
 Plugins have access to hook into the ``mautic:email:fetch`` command to fetch email from a specific inbox/folder and process the content of the message.
-The Plugin also has access to inject specific search criteria for the messages to be processed.
+The Plugin also has access to inject specific search criteria for the processed messages.
 
 To do this, the Plugin needs to add an event listener for three events:
 

--- a/docs/components/security.rst
+++ b/docs/components/security.rst
@@ -1,6 +1,8 @@
 Security
 ==========================================================
 
+.. _security-roles-and-permissions:
+
 Roles and permissions
 --------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ This is a work in progress. More to come soon. In the meantime, go to :xref:`Leg
    plugins/getting_started
    plugins/mautic_vs_symfony
    plugins/dependencies
+   plugins/event_listeners
    plugins/structure
    plugins/config
    plugins/installation

--- a/docs/links/ab_testing.py
+++ b/docs/links/ab_testing.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "A/B testing" 
+link_text = "A/B testing" 
+link_url = "https://kb.mautic.org/knowledgebase/emails/how-does-mautic-do-ab-testing" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/plugins/event_listeners.rst
+++ b/docs/plugins/event_listeners.rst
@@ -1,0 +1,2 @@
+Event listeners
+===============


### PR DESCRIPTION
Basically the [`Extending Mautic` section](https://developer.mautic.org/#extending-mautic) of the current developer docs.

Many code examples were outdated and I therefore updated/refactored those as part of the docs migration.

- [x] API
- [x] Broadcasts (moved to Channels)
- [ ] Cache
- [x] Campaigns (#17)
- [x] Categories
- [ ] Config
- [x] Contacts
- [x] Emails
- [x] Forms (#28)
- [ ] Integrations (note: replaced with IntegrationBundle as the PluginBundle's `AbstractIntegration` is deprecated)
- [ ] Maintenance Cleanup
- [ ] Landing Pages
- [ ] Points
- [ ] Reports
- [ ] Webhooks
- [ ] UI

Will work on the other elements in a follow-up PR!

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/26"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

