### PR TITLE
Revert "Bump sphinx from 4.4.0 to 5.0.2 in /docs"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # File: docs/requirements.txt
 
 # Defining the exact version will make sure things don't break
-sphinx==5.0.2
+sphinx==4.4.0
 sphinx_rtd_theme==1.0.0
 readthedocs-sphinx-search==0.1.1
 rstcheck==3.3.1


### PR DESCRIPTION
Reverts mautic/developer-documentation-new#44 as the builds are now failing (was working fine in Gitpod, and passing checks, looks like a dependency issue.)

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/47"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

