### PR TITLE
Add section about symfony commands

### DIFF
--- a/docs/plugins/mautic_vs_symfony.rst
+++ b/docs/plugins/mautic_vs_symfony.rst
@@ -53,6 +53,14 @@ Mautic built its own configuration system that services can access through Symfo
 
 Mautic 3 introduced support for Symfony's environment variables. Note that not all bundles support environment variables for Symfony's configuration so take this into account before using third party bundles. You can sometimes implement workarounds by using custom proxy or delegation services. For example, see ``\Mautic\EmailBundle\Swiftmailer\Spool\DelegatingSpool``.
 
+Included commands
+-----------------
+Mautic includes it's own commands in addition to commands defined by Symfony and Symfony bundles such as the makers bundle.
+
+Running ``./bin/console`` without any arguments outputs a list of available commands.
+
+.. note:: Some commands are only available in the development or test environments.
+
 Autowired services
 -------------------
 Mautic doesn't auto-wire native services other than Symfony commands and controllers.

--- a/docs/plugins/mautic_vs_symfony.rst
+++ b/docs/plugins/mautic_vs_symfony.rst
@@ -55,7 +55,7 @@ Mautic 3 introduced support for Symfony's environment variables. Note that not a
 
 Included commands
 -----------------
-Mautic includes it's own commands in addition to commands defined by Symfony and Symfony bundles such as the makers bundle.
+Mautic includes its own commands in addition to commands defined by Symfony and Symfony bundles such as the makers bundle.
 
 Running ``./bin/console`` without any arguments outputs a list of available commands.
 


### PR DESCRIPTION
This is in reference to https://github.com/mautic/mautic/pull/11313

I am adding a section on Symfony commands rather than documenting the maker command specifically.

I do not think we should document how to use commands we do not maintain.

A cookbook or best practices docs would be the best place to show how to use commands such as the makers command IMO.

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/49"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

