### PR TITLE
Fix indentation

### DIFF
--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -262,7 +262,7 @@ To do this, the Plugin needs to add an event listener for three events:
     }
 
 Email transports
-****************
+----------------
 
 Mautic supports quite some Email providers out of the box (Amazon Simple Email Service, SendGrid, etc.).
 If you want to add your own Email transport, that's certainly possible.


### PR DESCRIPTION
The heading was using the wrong markdown - this should fix it so that the transports heading is not nested underneath the monitored inbox section.

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/73"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

