### PR TITLE
Documentation for Forms

### DIFF
--- a/.github/styles/Vocab/Mautic/accept.txt
+++ b/.github/styles/Vocab/Mautic/accept.txt
@@ -109,6 +109,7 @@ SugarCRM
 Suhosin
 Symfony
 Todo
+tooltip
 Transifex
 TRUE
 true

--- a/docs/components/forms.rst
+++ b/docs/components/forms.rst
@@ -5,7 +5,7 @@ You can extend Forms by listening to the ``\Mautic\FormBundle\FormEvents::FORM_O
 At the bottom of this page, you can find code examples to make it easier to get started.
 
 Form fields
------------
+***********
 To add a custom Form field, use the ``$event->addFormField($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
 
 .. list-table::
@@ -66,7 +66,7 @@ To add a custom Form field, use the ``$event->addFormField($identifier, $paramet
             ];
 
 Form submit actions
--------------------
+*******************
 
 To add an action, use the ``$event->addSubmitAction($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
 
@@ -117,7 +117,7 @@ To do this, register a submit callback through the subscriber that processes the
 You can either inject the ``Symfony\Component\HttpFoundation\Response`` at that time with ``$event->setPostSubmitCallbackResponse($identifier, $response);`` or register another custom event to be dispatched after all submit actions have been processed using ``$event->setPostSubmitCallback($key, ['eventName' => HelloWorld::ANOTHER_CUSTOM_EVENT]);``.
 
 Form validations
-----------------
+****************
 
 To add a custom validation, use the ``$event->addValidator($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
 
@@ -145,7 +145,7 @@ The listener for the Form event receives a ``Mautic\FormBundle\Event\ValidationE
 Obtain the field with ``$event->getField();``, do the logic to fail a validation, then execute ``$event->failedValidation('I said so.');``.
 
 Example code
-------------
+************
 
 .. code-block:: PHP
 

--- a/docs/components/forms.rst
+++ b/docs/components/forms.rst
@@ -1,4 +1,197 @@
 Forms
 #####
 
+You can extend Forms by listening to the ``\Mautic\FormBundle\FormEvents::FORM_ON_BUILD`` event.  Read more about :doc:`listeners and subscribers</plugins/event_listeners>`. 
 
+Form fields
+-----------
+To add a custom form field, use the ``$event->addFormField($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Key
+      - Required
+      - Type
+      - Description
+    * - ``label``
+      - Required
+      - string
+      - The language string for the option in the dropdown
+    * - ``formType``
+      - Required
+      - string
+      - The alias of a custom Form type used to set config options
+    * - ``template``
+      - Required
+      - string
+      - View template used to render the formType, for example ``HelloWorldBundle:SubscribedEvents\FormField:customfield.html.php``
+    * - ``formTypeOptions``
+      - Optional
+      - array
+      - Array of options to include into the formType's $options argument
+    * - ``formTypeCleanMasks``
+      - Optional
+      - array
+      - Array of input masks to clean a values from formType
+    * - ``formTypeTheme``
+      - Optional
+      - array
+      - Array of input masks to clean a values from formType
+    * - ``valueFilter``
+      - Optional
+      - mixed
+      - Filter to use to clean the submitted value as supported by InputHelper or a callback function that accepts the arguments ``\Mautic\FormBundle\Entity\Field $field`` and ``$value``.
+    * - ``valueConstraints``
+      - Optional
+      - mixed
+      - Callback function to use to validate the value; the function should accept the arguments ``\Mautic\FormBundle\Entity\Field $field`` and ``$filteredValue``.
+    * - ``builderOptions``
+      - Optional
+      - array
+      - Array of boolean options for the Form builder:
+        
+        .. code-block:: PHP
+
+            <?php
+
+            $builderOptions = [
+                'addHelpMessage' => true,
+                'addShowLabel' => true,
+                'addDefaultValue' => true,
+                'addLabelAttributes' => true,
+                'addInputAttributes' => true,
+                'addIsRequired' => true
+            ];
+
+Form Submit Actions
+-------------------
+
+To add an action, use the `$event->addSubmitAction($identifier, $parameters)` method. `$identifier` must be something unique. The `$parameters` array can contain the following elements:
+ 
+Key|Required|Type|Description
+---|--------|----|-----------
+**label**|REQUIRED|string|The language string for the option in the dropdown
+**description**|OPTIONAL|string|The language string to use for the option's tooltip
+**eventName**|REQUIRED|string|This is the custom event name that will be dispatched to handle this action (`callback` has been deprecated)
+**formType**|OPTIONAL|string|The alias of a custom form type used to set config options
+**formTypeOptions**|OPTIONAL|array|Array of options to include into the formType's $options argument
+**formTypeCleanMasks**|OPTIONAL|array|Array of input masks to clean a values from formType
+**formTypeTheme**|OPTIONAL|string|Theme to customize elements for formType
+**template**|OPTIONAL|string|View template used to render the formType 
+**validator**|DEPRECATED|mixed|Static callback function called to validate the form submission. Deprecated - Register a validator using the `$event->addValidator()`. 
+**callback**|DEPRECATED|mixed|Static callback function called after a submission (submit action logic goes here). Deprecated - use eventName instead.
+
+The subscriber registered to listen to the `eventName` will be passed an instance of `Mautic\FormBundle\Events\SubmissionEvent` with the details about the post. 
+ 
+Sometimes, it is necessary to handle something after all the other submit actions have done their thing - like redirect to another page. This is done by registering a post submit callback through the subscriber that processes the action. You can either inject the `Symfony\Component\HttpFoundation\Response` at that time with `$event->setPostSubmitCallbackResponse($response);` or register another custom event to be dispatched after all submit actions have been processed using `$event->setPostSubmitCallback($key, ['eventName' => HelloWorld::ANOTHER_CUSTOM_EVENT]);`.
+
+Form Validations
+----------------
+
+To add a custom validation, use the `$event->addValidator($identifier, $parameters)` method. `$identifier` must be something unique. The `$parameters` array can contain the following elements:
+
+Key|Required|Type|Description
+---|--------|----|-----------
+**eventName**|REQUIRED|string|The name of the custom event that will be dispatched to validate the form or specific field
+**fieldType**|optional|string|The key to a custom form type (for example something registered by `addFormField()`) to limit this listener to. Otherwise every field will be sent to listener.
+**formType**|optional|string|Form type class to generate additional fields to validator tab
+  
+The listener for the form event will receive a `Mautic\FormBundle\Event\ValidationEvent` object. Obtain the field with `$event->getField();` do the logic then to fail a validation, execute `$event->failedValidation('I said so.');`.
+
+Example code
+------------
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/FormSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use MauticPlugin\HelloWorldBundle\HelloWorldEvents;
+    use Mautic\FormBundle\Event\FormBuilderEvent;
+    use Mautic\FormBundle\Event\ValidationEvent;
+    use Mautic\FormBundle\FormEvents;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class FormSubscriber implements EventSubscriberInterface
+    {
+        /**
+        * {@inheritdoc}
+        */
+        static public function getSubscribedEvents()
+        {
+            return [
+                FormEvents::FORM_ON_BUILD     => ['onFormBuilder', 0],
+                FormEvents::ON_FORM_VALIDATE  => ['onFormValidate', 0],
+
+            ];
+        }
+
+        /**
+        * Add a simple email form
+        */
+        public function onFormBuilder(FormBuilderEvent $event): void
+        {
+            // Register a custom form field
+            $event->addFormField(
+                'helloworld.customfield',
+                [
+                    // Field label
+                    'label'    => 'plugin.helloworld.formfield.customfield',
+                    
+                    // Form service for the field's configuration
+                    'formType' => 'helloworld_worlds',
+                    
+                    // Template to use to render the formType
+                    'template' => 'HelloWorldBundle:SubscribedEvents\FormField:customfield.html.php'
+                ]
+            );
+
+            // Register a form submit actions
+            $event->addSubmitAction(
+                'helloworld.sendemail',
+                [
+                    // Label to group by in the dropdown
+                    'group'       => 'plugin.helloworld.header',
+                    
+                    // Label to list by in the dropdown
+                    'label'       => 'plugin.helloworld.formaction.send_email',
+                    'description' => 'plugin.helloworld.formaction.send_email_descr',
+                    
+                    // Form service for custom config options
+                    'formType'    => 'helloworld_worlds',
+                    'formTheme'   => 'HelloWorldBundle:FormTheme\SubmitAction',
+                    
+                    // Callback method to be executed after the submission 
+                    'eventName'    => HelloWorldEvents::FORM_SUBMIT_ACTION
+                ]
+            );
+
+            // Register a custom validation service
+            $event->addValidator(
+                'helloworld.customfield',
+                [
+                    'eventName' => HelloWorldEvents::FORM_VALIDATION,
+                    'fieldType' => 'helloworld.customfield', // Optional - otherwise all fields will be sent through this listener for validation
+                    'formType' => \MauticPlugin\HelloWorldBundle\Form\Type\HelloWorldType::class // Optional - otherwise just default required option should be generated to validation tab 
+                    
+                ]
+            );
+        }
+        
+        public function onFormValidate(ValidationEvent $event): void
+        {
+            $field = $event->getField();
+            if ($field->getType() === 'helloworld.customfield' && !empty($field->getValidation()['c_enable'])) {
+                if (empty($field->getValidation()['helloworld_customfield_enable_validationmsg'])) {
+                    $event->failedValidation($field->getValidation()['helloworld_customfield_enable_validationmsg']);
+                } else {
+                    $event->failedValidation('plugin.helloworld.formfield.customfield.invalid');
+                }
+            }
+        }
+    }

--- a/docs/components/forms.rst
+++ b/docs/components/forms.rst
@@ -2,11 +2,16 @@ Forms
 #####
 
 You can extend Forms by listening to the ``\Mautic\FormBundle\FormEvents::FORM_ON_BUILD`` event. Read more about :doc:`listeners and subscribers</plugins/event_listeners>`.
-At the bottom of this page, you can find code examples to make it easier to get started.
+At the bottom of this document, you can find code examples to make it easier to get started.
 
-Form fields
+.. vale off
+
+Form Fields
 ***********
-To add a custom Form field, use the ``$event->addFormField($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
+
+.. vale on
+
+To add a custom Form Field, use the ``$event->addFormField($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
 
 .. list-table::
     :header-rows: 1
@@ -26,19 +31,19 @@ To add a custom Form field, use the ``$event->addFormField($identifier, $paramet
     * - ``template``
       - Required
       - string
-      - View template used to render the formType, for example ``HelloWorldBundle:SubscribedEvents\FormField:customfield.html.php``
+      - View template used to render the ``formType``, for example ``HelloWorldBundle:SubscribedEvents\FormField:customfield.html.php``
     * - ``formTypeOptions``
       - Optional
       - array
-      - Array of options to include into the formType's $options argument
+      - Array of options to include into the ``formType``'s $options argument
     * - ``formTypeCleanMasks``
       - Optional
       - array
-      - Array of input masks to clean a values from formType
+      - Array of input masks to clean a values from ``formType``
     * - ``formTypeTheme``
       - Optional
       - array
-      - Array of input masks to clean a values from formType
+      - Array of input masks to clean a values from ``formType``
     * - ``valueFilter``
       - Optional
       - mixed
@@ -96,19 +101,19 @@ To add an action, use the ``$event->addSubmitAction($identifier, $parameters)`` 
     * - ``formTypeOptions``
       - Optional
       - array
-      - Array of options to include into the formType's ``$options`` argument
+      - Array of options to include into the ``formType``'s ``$options`` argument
     * - ``formTypeCleanMasks``
       - Optional
       - array
-      - Array of input masks to clean a values from formType
+      - Array of input masks to clean a values from ``formType``
     * - ``formTypeTheme``
       - Optional
       - string
-      - Theme to customize elements for formType
+      - Theme to customize elements for ``formType``
     * - ``template``
       - Optional
       - string
-      - View template used to render the formType
+      - View template used to render the ``formType``
 
 The subscriber registered to listen to the ``eventName`` gets an instance of ``Mautic\FormBundle\Events\SubmissionEvent`` with the details about the submission. 
  

--- a/docs/components/forms.rst
+++ b/docs/components/forms.rst
@@ -1,11 +1,12 @@
 Forms
 #####
 
-You can extend Forms by listening to the ``\Mautic\FormBundle\FormEvents::FORM_ON_BUILD`` event.  Read more about :doc:`listeners and subscribers</plugins/event_listeners>`. 
+You can extend Forms by listening to the ``\Mautic\FormBundle\FormEvents::FORM_ON_BUILD`` event. Read more about :doc:`listeners and subscribers</plugins/event_listeners>`.
+At the bottom of this page, you can find code examples to make it easier to get started.
 
 Form fields
 -----------
-To add a custom form field, use the ``$event->addFormField($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
+To add a custom Form field, use the ``$event->addFormField($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
 
 .. list-table::
     :header-rows: 1
@@ -64,40 +65,84 @@ To add a custom form field, use the ``$event->addFormField($identifier, $paramet
                 'addIsRequired' => true
             ];
 
-Form Submit Actions
+Form submit actions
 -------------------
 
-To add an action, use the `$event->addSubmitAction($identifier, $parameters)` method. `$identifier` must be something unique. The `$parameters` array can contain the following elements:
- 
-Key|Required|Type|Description
----|--------|----|-----------
-**label**|REQUIRED|string|The language string for the option in the dropdown
-**description**|OPTIONAL|string|The language string to use for the option's tooltip
-**eventName**|REQUIRED|string|This is the custom event name that will be dispatched to handle this action (`callback` has been deprecated)
-**formType**|OPTIONAL|string|The alias of a custom form type used to set config options
-**formTypeOptions**|OPTIONAL|array|Array of options to include into the formType's $options argument
-**formTypeCleanMasks**|OPTIONAL|array|Array of input masks to clean a values from formType
-**formTypeTheme**|OPTIONAL|string|Theme to customize elements for formType
-**template**|OPTIONAL|string|View template used to render the formType 
-**validator**|DEPRECATED|mixed|Static callback function called to validate the form submission. Deprecated - Register a validator using the `$event->addValidator()`. 
-**callback**|DEPRECATED|mixed|Static callback function called after a submission (submit action logic goes here). Deprecated - use eventName instead.
+To add an action, use the ``$event->addSubmitAction($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
 
-The subscriber registered to listen to the `eventName` will be passed an instance of `Mautic\FormBundle\Events\SubmissionEvent` with the details about the post. 
- 
-Sometimes, it is necessary to handle something after all the other submit actions have done their thing - like redirect to another page. This is done by registering a post submit callback through the subscriber that processes the action. You can either inject the `Symfony\Component\HttpFoundation\Response` at that time with `$event->setPostSubmitCallbackResponse($response);` or register another custom event to be dispatched after all submit actions have been processed using `$event->setPostSubmitCallback($key, ['eventName' => HelloWorld::ANOTHER_CUSTOM_EVENT]);`.
+.. list-table::
+    :header-rows: 1
 
-Form Validations
+    * - Key
+      - Required
+      - Type
+      - Description
+    * - ``label``
+      - Required
+      - string
+      - The language string for the option in the dropdown
+    * - ``eventName``
+      - Required
+      - string
+      - This is the custom event name that gets dispatched to handle this action. It receives a ``SubmissionEvent`` object
+    * - ``description``
+      - Optional
+      - string
+      - The language string to use for the option's tooltip
+    * - ``formType``
+      - Optional
+      - string
+      - The alias of a custom Form type used to set config options
+    * - ``formTypeOptions``
+      - Optional
+      - array
+      - Array of options to include into the formType's ``$options`` argument
+    * - ``formTypeCleanMasks``
+      - Optional
+      - array
+      - Array of input masks to clean a values from formType
+    * - ``formTypeTheme``
+      - Optional
+      - string
+      - Theme to customize elements for formType
+    * - ``template``
+      - Optional
+      - string
+      - View template used to render the formType
+
+The subscriber registered to listen to the ``eventName`` gets an instance of ``Mautic\FormBundle\Events\SubmissionEvent`` with the details about the submission. 
+ 
+Sometimes, it's necessary to handle something after all the other submit actions have done their thing - like redirecting to another URL.
+To do this, register a submit callback through the subscriber that processes the action.
+You can either inject the ``Symfony\Component\HttpFoundation\Response`` at that time with ``$event->setPostSubmitCallbackResponse($identifier, $response);`` or register another custom event to be dispatched after all submit actions have been processed using ``$event->setPostSubmitCallback($key, ['eventName' => HelloWorld::ANOTHER_CUSTOM_EVENT]);``.
+
+Form validations
 ----------------
 
-To add a custom validation, use the `$event->addValidator($identifier, $parameters)` method. `$identifier` must be something unique. The `$parameters` array can contain the following elements:
+To add a custom validation, use the ``$event->addValidator($identifier, $parameters)`` method. ``$identifier`` must be something unique. The ``$parameters`` array can contain the following elements:
 
-Key|Required|Type|Description
----|--------|----|-----------
-**eventName**|REQUIRED|string|The name of the custom event that will be dispatched to validate the form or specific field
-**fieldType**|optional|string|The key to a custom form type (for example something registered by `addFormField()`) to limit this listener to. Otherwise every field will be sent to listener.
-**formType**|optional|string|Form type class to generate additional fields to validator tab
-  
-The listener for the form event will receive a `Mautic\FormBundle\Event\ValidationEvent` object. Obtain the field with `$event->getField();` do the logic then to fail a validation, execute `$event->failedValidation('I said so.');`.
+.. list-table::
+    :header-rows: 1
+
+    * - Key
+      - Required
+      - Type
+      - Description
+    * - ``eventName``
+      - Required
+      - string
+      - The name of the custom event that gets dispatched to validate the Form or specific field
+    * - ``fieldType``
+      - Optional
+      - string
+      - The key to a custom Form type, for example something registered by ``addFormField()``, to limit this listener to. Otherwise every field gets sent to listener.
+    * - ``formType``
+      - Optional
+      - string
+      - Form type class to generate additional fields for the ``validator`` tab
+
+The listener for the Form event receives a ``Mautic\FormBundle\Event\ValidationEvent`` object.
+Obtain the field with ``$event->getField();``, do the logic to fail a validation, then execute ``$event->failedValidation('I said so.');``.
 
 Example code
 ------------
@@ -113,9 +158,12 @@ Example code
 
     use MauticPlugin\HelloWorldBundle\HelloWorldEvents;
     use Mautic\FormBundle\Event\FormBuilderEvent;
+    use Mautic\FormBundle\Event\SubmissionEvent;
     use Mautic\FormBundle\Event\ValidationEvent;
     use Mautic\FormBundle\FormEvents;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Component\HttpFoundation\RedirectResponse;
+    use Symfony\Component\HttpFoundation\Response;
 
     class FormSubscriber implements EventSubscriberInterface
     {
@@ -125,9 +173,12 @@ Example code
         static public function getSubscribedEvents()
         {
             return [
-                FormEvents::FORM_ON_BUILD     => ['onFormBuilder', 0],
-                FormEvents::ON_FORM_VALIDATE  => ['onFormValidate', 0],
-
+                FormEvents::FORM_ON_BUILD                         => ['onFormBuilder', 0],
+                // Generic validation function that runs on ALL field types
+                FormEvents::ON_FORM_VALIDATE                      => ['onFormValidate', 0],
+                HelloWorldEvents::ON_FORM_SUBMISSION              => ['onFormSubmission', 0],
+                // Only validates our custom field type (helloworld.customfield)
+                HelloWorldEvents::ON_FORM_CUSTOM_FIELD_VALIDATION => ['onFormValidateCustomFIeld', 0]
             ];
         }
 
@@ -166,32 +217,116 @@ Example code
                     'formType'    => 'helloworld_worlds',
                     'formTheme'   => 'HelloWorldBundle:FormTheme\SubmitAction',
                     
-                    // Callback method to be executed after the submission 
-                    'eventName'    => HelloWorldEvents::FORM_SUBMIT_ACTION
+                    // Callback method to be executed after the submission
+                    'eventName'    => HelloWorldEvents::ON_FORM_SUBMISSION
                 ]
             );
 
-            // Register a custom validation service
+            /**
+            * Register a custom validation service. This is only needed if:
+            * - you only want to validate your custom field type (the generic FormEvents::ON_FORM_VALIDATE runs on all field types which is less efficient)
+            * - you have more complex validation logic that you want to have in its own event listener
+            * 
+            * In all other cases, you can simply listen to FormEvents::ON_FORM_VALIDATE as shown in onFormValidate() below.
+            */
             $event->addValidator(
                 'helloworld.customfield',
                 [
-                    'eventName' => HelloWorldEvents::FORM_VALIDATION,
-                    'fieldType' => 'helloworld.customfield', // Optional - otherwise all fields will be sent through this listener for validation
-                    'formType' => \MauticPlugin\HelloWorldBundle\Form\Type\HelloWorldType::class // Optional - otherwise just default required option should be generated to validation tab 
-                    
+                    'eventName' => HelloWorldEvents::ON_FORM_CUSTOM_FIELD_VALIDATION,
+                    // Optional - otherwise all fields will be sent through this listener for validation
+                    'fieldType' => 'helloworld.customfield',
+                    // Optional - otherwise just default required option should be generated to validation tab
+                    'formType' => \MauticPlugin\HelloWorldBundle\Form\Type\HelloWorldType::class
                 ]
             );
         }
         
+        /**
+        * Generic validation function that runs on ALL field types.
+        * For efficiency reasons, it's recommended to set up a custom validator (see $event->addValidator() above) if you
+        * only need to validate a custom field type.
+        */
         public function onFormValidate(ValidationEvent $event): void
         {
             $field = $event->getField();
-            if ($field->getType() === 'helloworld.customfield' && !empty($field->getValidation()['c_enable'])) {
-                if (empty($field->getValidation()['helloworld_customfield_enable_validationmsg'])) {
-                    $event->failedValidation($field->getValidation()['helloworld_customfield_enable_validationmsg']);
+            $validation = $field->getValidation();
+
+            if ($field->getType() === 'helloworld.customfield' && !empty($validation['c_enable'])) {
+                if (empty($validation['helloworld_customfield_enable_validationmsg'])) {
+                    $event->failedValidation($validation['helloworld_customfield_enable_validationmsg']);
                 } else {
                     $event->failedValidation('plugin.helloworld.formfield.customfield.invalid');
                 }
             }
         }
+
+        /**
+        * Validation function that we registered specifically for our custom field type (helloworld.customfield).
+        * We don't need to check the field in this case, because it'll only trigger when validating our custom field
+        * (see $event->addValidator() above).
+        */
+        public function onFormValidateCustomField(ValidationEvent $event): void
+        {
+            $field = $event->getField();
+            $validation = $field->getValidation();
+
+            if (!empty($validation['c_enable'])) {
+                if (empty($validation['helloworld_customfield_enable_validationmsg'])) {
+                    $event->failedValidation($$validation['helloworld_customfield_enable_validationmsg']);
+                } else {
+                    $event->failedValidation('plugin.helloworld.formfield.customfield.invalid');
+                }
+            }
+        }
+
+        public function onFormSubmission(SubmissionEvent $event): void
+        {
+            // Get the submitted data
+            $data = $event->getPost();
+
+            // Redirect to an external URL after the form has been submitted
+            $event->setPostSubmitCallbackResponse('helloworld.submit.response', new RedirectResponse('https://mydomain.com'));
+
+            // Dispatch a custom event to be dispatched after all submit actions have been processed
+            $event->setPostSubmitCallback('helloworld.submit.callback', [
+                'eventName' => HelloWorldEvents::ON_FORM_SUBMISSION_CALLBACK
+            ]);
+        }
+    }
+
+.. code-block:: PHP
+
+    <?php
+
+    namespace MauticPlugin\HelloWorldBundle;
+
+    final class HelloWorldEvents
+    {
+        /**
+        * The plugin.hello.world.on_form_submission event is fired when a form is submitted.
+        *
+        * The event listener receives a Mautic\FormBundle\Events\SubmissionEvent
+        *
+        * @var string
+        */
+        public const ON_FORM_SUBMISSION = 'plugin.hello.world.on_form_submission';
+
+        /**
+        * The plugin.hello.world.on_form_submission_callback event is fired after all submit actions have been processed
+        *
+        * The event listener receives a Mautic\FormBundle\Events\SubmissionEvent
+        *
+        * @var string
+        */
+        public const ON_FORM_SUBMISSION_CALLBACK = 'plugin.hello.world.on_form_submission_callback';
+
+        /**
+        * The plugin.hello.world.on_form_validation event is fired when our custom field type (helloworld.customfield)
+        * is being validated in a form submission.
+        *
+        * The event listener receives a Mautic\FormBundle\Event\ValidationEvent
+        *
+        * @var string
+        */
+        public const ON_FORM_CUSTOM_FIELD_VALIDATION = 'plugin.hello.world.on_form_custom_field_validation';
     }

--- a/docs/components/forms_advanced.rst
+++ b/docs/components/forms_advanced.rst
@@ -1,0 +1,188 @@
+Forms - advanced
+################
+
+Sometimes you might have more complex requirements for your Forms. You might already be aware that Mautic builds upon the Symfony framework, so there's lots of Form-related features available to you.
+You can read more about this here: :xref:`Symfony 4 form classes`. This section highlights a few complex but common use cases:
+
+- Custom Form Types that deviate from Symfony's wide array of standard Form types, like text fields, choice fields, etc.
+- Data sanitizing
+- Dynamic Form modification
+- Data validation
+
+Custom Form types
+*****************
+
+As stated in Symfony's documentation as referenced in the preceding section, Form type classes are the best way to go.
+Mautic makes it easy to register :xref:`Form type services<Symfony 4 custom form field type>` through the bundle's config file.
+Refer to the :ref:`Service config items` section.
+
+Data sanitizing
+***************
+
+Form data isn't automatically sanitized. Mautic provides a Form event subscriber to handle this. 
+
+In your :xref:`Form type class<Symfony 4 form classes>`, register the ``Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber`` event subscriber. 
+ 
+The array provided to ``CleanFormSubscriber`` should contain the names of the Form fields as keys and the values the masks to use to sanitize the data. Any unspecified Form field uses the ``clean`` mask by default.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Form/Type/WorldType.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\Form\Type;
+
+    use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilderInterface;
+
+    class WorldType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options)
+        {
+            $builder->addEventSubscriber(
+                new CleanFormSubscriber(
+                    [
+                        'content'    => 'html',
+                        'customHtml' => 'html'
+                    ]
+                )
+            );
+        }
+    }
+
+Dynamic Form modification
+*************************
+
+If you need to manipulate a Form based on submitted data, use a Form event listener.
+This is useful in cases like changing defined fields, adjust constraints, or changing select choices based on submitted values.
+Refer to Symfony's documentation on this: :xref:`Symfony 4 dynamic form modification`
+
+Data validation
+***************
+
+Review Symfony's Form validation documentation for a general overview: :xref:`Symfony 4 form validation`
+
+There are two common means of validating Form data.
+
+Using entity static callback
+============================
+
+If the underlying data of a Form is an Entity object you can define a static method ``loadValidatorMetadata`` in the Entity class.
+This automatically gets called when Symfony is processing Form data.
+
+A Form can also use :xref:`validation_groups<Symfony 4 form validation groups>` to change the order of data to validate or only validate if certain criteria is true.
+For example, only validate a password confirmation field if the first password field passes validation.
+When registering a validation group in the form type class, you can use a static callback to determine what validation groups Symfony should use.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Form/Type/WorldType.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\Form\Type;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Form;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
+    use Symfony\Component\Validator\Constraints\NotBlank;
+    use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+    class WorldType extends AbstractType
+    {
+        public function configureOptions(OptionsResolver $resolver)
+        {
+            $resolver->setDefaults(array(
+                'data_class'        => 'MauticPlugin\HelloWorld\Entity\World',
+                'validation_groups' => array(
+                    'MauticPlugin\HelloWorld\Entity\World',
+                    'determineValidationGroups',
+                )
+            ));
+        }
+
+        public static function loadValidatorMetadata(ClassMetadata $metadata)
+        {
+            $metadata->addPropertyConstraint(
+                'name',
+                new NotBlank(
+                    array(
+                        'message' => 'mautic.core.name.required'
+                    )
+                )
+            );
+            
+            $metadata->addPropertyConstraint(
+                'population', 
+                new NotBlank(
+                    array(
+                        'message' => 'mautic.core.value.required',
+                        'groups'  => array('VisitedWorld')
+                    )
+                
+                )
+            );
+        }
+
+        public static function determineValidationGroups(Form $form)
+        {
+            $data   = $form->getData();
+            $groups = array('AllWorlds');
+
+            if (!$data->getId() || ($data->getId() && $data->getVisitCount() > 0)) {
+                $groups[] = 'VisitedWorld';
+            }
+
+            return $groups;
+        }
+    }
+
+
+Using constraints
+=================
+
+A :xref:`Form type service<Symfony 4 custom form field type>` can also register :xref:`Constraints<Symfony 4 form constraints>` when defining the form fields.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Form/Type/WorldType.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\Form\Type;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Form;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Validator\Constraints\NotBlank;
+
+    class WorldType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options)
+        {
+            $builder->add(
+                'name',
+                'text',
+                array(
+                    'label'       => 'mautic.core.name',
+                    'label_attr'  => array('class' => 'control-label'),
+                    'attr'        => array(
+                        'class'   => 'form-control'
+                    ),
+                    'constraints' => array(
+                        new NotBlank(
+                            array(
+                                'message' => 'mautic.core.value.required'
+                            )
+                        )
+                    )
+                )
+            );
+        }
+    }

--- a/docs/components/forms_advanced.rst
+++ b/docs/components/forms_advanced.rst
@@ -13,7 +13,7 @@ Custom Form types
 *****************
 
 As stated in Symfony's documentation as referenced in the preceding section, Form type classes are the best way to go.
-Mautic makes it easy to register :xref:`Form type services<Symfony 4 custom form field type>` through the bundle's config file.
+Mautic makes it easy to register :xref:`Form type services<Symfony 4 custom Form field type>` through the bundle's config file.
 Refer to the :ref:`Service config items` section.
 
 Data sanitizing

--- a/docs/components/forms_advanced.rst
+++ b/docs/components/forms_advanced.rst
@@ -9,8 +9,12 @@ You can read more about this here: :xref:`Symfony 4 form classes`. This section 
 - Dynamic Form modification
 - Data validation
 
+.. vale off
+
 Custom Form types
 *****************
+
+.. vale on
 
 As stated in Symfony's documentation as referenced in the preceding section, Form type classes are the best way to go.
 Mautic makes it easy to register :xref:`Form type services<Symfony 4 custom Form field type>` through the bundle's config file.
@@ -23,7 +27,7 @@ Form data isn't automatically sanitized. Mautic provides a Form event subscriber
 
 In your :xref:`Form type class<Symfony 4 form classes>`, register the ``Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber`` event subscriber. 
  
-The array provided to ``CleanFormSubscriber`` should contain the names of the Form fields as keys and the values the masks to use to sanitize the data. Any unspecified Form field uses the ``clean`` mask by default.
+The array provided to ``CleanFormSubscriber`` should contain the names of the Form Fields as keys and the values the masks to use to sanitize the data. Any unspecified Form field uses the ``clean`` mask by default.
 
 .. code-block:: php
 
@@ -53,8 +57,12 @@ The array provided to ``CleanFormSubscriber`` should contain the names of the Fo
         }
     }
 
+.. vale off
+
 Dynamic Form modification
 *************************
+
+.. vale on
 
 If you need to manipulate a Form based on submitted data, use a Form event listener.
 This is useful in cases like changing defined fields, adjust constraints, or changing select choices based on submitted values.
@@ -73,9 +81,9 @@ Using entity static callback
 If the underlying data of a Form is an Entity object you can define a static method ``loadValidatorMetadata`` in the Entity class.
 This automatically gets called when Symfony is processing Form data.
 
-A Form can also use :xref:`validation_groups<Symfony 4 form validation groups>` to change the order of data to validate or only validate if certain criteria is true.
+A Form can also use :xref:`validation_groups<Symfony 4 Form validation groups>` to change the order of data to validate or only validate if certain criteria is true.
 For example, only validate a password confirmation field if the first password field passes validation.
-When registering a validation group in the form type class, you can use a static callback to determine what validation groups Symfony should use.
+When registering a validation group in the Form type class, you can use a static callback to determine what validation groups Symfony should use.
 
 .. code-block:: php
 
@@ -146,7 +154,7 @@ When registering a validation group in the form type class, you can use a static
 Using constraints
 =================
 
-A :xref:`Form type service<Symfony 4 custom Form field type>` can also register :xref:`Constraints<Symfony 4 form constraints>` when defining the form fields.
+A :xref:`Form type service<Symfony 4 custom Form field type>` can also register :xref:`Constraints<Symfony 4 Form constraints>` when defining the Form fields.
 
 .. code-block:: php
 

--- a/docs/components/forms_advanced.rst
+++ b/docs/components/forms_advanced.rst
@@ -146,7 +146,7 @@ When registering a validation group in the form type class, you can use a static
 Using constraints
 =================
 
-A :xref:`Form type service<Symfony 4 custom form field type>` can also register :xref:`Constraints<Symfony 4 form constraints>` when defining the form fields.
+A :xref:`Form type service<Symfony 4 custom Form field type>` can also register :xref:`Constraints<Symfony 4 form constraints>` when defining the form fields.
 
 .. code-block:: php
 

--- a/docs/components/forms_advanced.rst
+++ b/docs/components/forms_advanced.rst
@@ -27,7 +27,7 @@ Form data isn't automatically sanitized. Mautic provides a Form event subscriber
 
 In your :xref:`Form type class<Symfony 4 form classes>`, register the ``Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber`` event subscriber. 
  
-The array provided to ``CleanFormSubscriber`` should contain the names of the Form Fields as keys and the values the masks to use to sanitize the data. Any unspecified Form field uses the ``clean`` mask by default.
+The array provided to ``CleanFormSubscriber`` should contain the names of the Form Fields as keys and the values the masks to use to sanitize the data. Any unspecified Form Field uses the ``clean`` mask by default.
 
 .. code-block:: php
 
@@ -154,7 +154,7 @@ When registering a validation group in the Form type class, you can use a static
 Using constraints
 =================
 
-A :xref:`Form type service<Symfony 4 custom Form field type>` can also register :xref:`Constraints<Symfony 4 Form constraints>` when defining the Form fields.
+A :xref:`Form type service<Symfony 4 custom Form field type>` can also register :xref:`Constraints<Symfony 4 Form constraints>` when defining the Form Fields.
 
 .. code-block:: php
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ This is a work in progress. More to come soon. In the meantime, go to :xref:`Leg
    components/core
    components/emails
    components/forms
+   components/forms_advanced
    components/integrations
    components/ip_lookups
    components/landing_pages

--- a/docs/links/symfony_docs_constraints.py
+++ b/docs/links/symfony_docs_constraints.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony 4 form constraints"
+link_text = "Symfony 4 form constraints"
+link_url = "https://symfony.com/doc/4.4/reference/constraints.html" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_constraints.py
+++ b/docs/links/symfony_docs_constraints.py
@@ -1,7 +1,7 @@
 from . import link
 
-link_name = "Symfony 4 form constraints"
-link_text = "Symfony 4 form constraints"
+link_name = "Symfony 4 Form constraints"
+link_text = "Symfony 4 Form constraints"
 link_url = "https://symfony.com/doc/4.4/reference/constraints.html" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_custom_form_fields.py
+++ b/docs/links/symfony_docs_custom_form_fields.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony 4 custom form fields"
+link_text = "Symfony 4 custom form fields"
+link_url = "https://symfony.com/doc/4.4/form/create_custom_field_type.html" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_custom_form_fields_type.py
+++ b/docs/links/symfony_docs_custom_form_fields_type.py
@@ -1,7 +1,7 @@
 from . import link
 
-link_name = "Symfony 4 custom form field type"
-link_text = "Symfony 4 custom form field type"
+link_name = "Symfony 4 custom Form field type"
+link_text = "Symfony 4 custom Form field type"
 link_url = "https://symfony.com/doc/4.4/form/create_custom_field_type.html#defining-the-form-type" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_custom_form_fields_type.py
+++ b/docs/links/symfony_docs_custom_form_fields_type.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony 4 custom form field type"
+link_text = "Symfony 4 custom form field type"
+link_url = "https://symfony.com/doc/4.4/form/create_custom_field_type.html#defining-the-form-type" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_dynamic_form_modification.py
+++ b/docs/links/symfony_docs_dynamic_form_modification.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony 4 dynamic form modification"
+link_text = "Symfony 4 dynamic form modification"
+link_url = "https://symfony.com/doc/4.4/form/dynamic_form_modification.html" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_form_classes.py
+++ b/docs/links/symfony_docs_form_classes.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony 4 form classes"
+link_text = "Symfony 4 form classes"
+link_url = "https://symfony.com/doc/4.4/forms.html#creating-form-classes" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_form_validation.py
+++ b/docs/links/symfony_docs_form_validation.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony 4 form validation"
+link_text = "Symfony 4 form validation"
+link_url = "https://symfony.com/doc/4.4/forms.html#validating-forms" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_form_validation_groups.py
+++ b/docs/links/symfony_docs_form_validation_groups.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony 4 form validation groups"
+link_text = "Symfony 4 form validation groups"
+link_url = "https://symfony.com/doc/4.4/form/validation_groups.html" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_docs_form_validation_groups.py
+++ b/docs/links/symfony_docs_form_validation_groups.py
@@ -1,7 +1,7 @@
 from . import link
 
-link_name = "Symfony 4 form validation groups"
-link_text = "Symfony 4 form validation groups"
+link_name = "Symfony 4 Form validation groups"
+link_text = "Symfony 4 Form validation groups"
 link_url = "https://symfony.com/doc/4.4/form/validation_groups.html" 
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
Closes #61

I've also updated the Code Samples because they were either incomplete or referencing old Symfony 2 code.

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/86"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

