### PR TITLE
Use updated Vale action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,6 +13,8 @@ jobs:
 
     - name: Vale
       uses: errata-ai/vale-action@reviewdog
+      with:
+        filter_mode: nofilter
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,7 +14,8 @@ jobs:
     - name: Vale
       uses: errata-ai/vale-action@reviewdog
       with:
-        filter_mode: nofilter
+        # Please keep version in sync with the version in .gitpod.Dockerfile for a consistent experience
+        version: 2.20.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,5 @@
 name: Linting
 on:
-  # Note: onlyAnnotateModifiedLines only works correctly on PRs!
-  # If you need to run checks on push as well, create a separate workflow file.
   pull_request:
 
 jobs:
@@ -14,12 +12,7 @@ jobs:
         fetch-depth: 0
 
     - name: Vale
-      uses: errata-ai/vale-action@master
-      with:
-        # We can modify these styles as we want
-        styles: |
-          https://github.com/errata-ai/Google/releases/latest/download/Google.zip
-        onlyAnnotateModifiedLines: true
+      uses: errata-ai/vale-action@reviewdog
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10
 
 # Don't update to a higher version until this issue has been fixed: https://github.com/errata-ai/vale/issues/528
+# Please keep version in sync with the version in .github/workflows/linting.yml for a consistent experience
 ENV VALE_VERSION=2.20.2
 
 WORKDIR /workspace


### PR DESCRIPTION
The updated Vale action uses [reviewdog](https://github.com/reviewdog/reviewdog), which ensures that review comments can also be posted on PRs from forks (which currently doesn't work due to [this issue](https://github.com/errata-ai/vale-action/issues/12)).

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/87"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

