### PR TITLE
Add maintenance docs

### DIFF
--- a/docs/components/maintenance.rst
+++ b/docs/components/maintenance.rst
@@ -1,15 +1,15 @@
 Extending maintenance cleanup
 #############################
 
-To hook into the ``mautic:maintenance:cleanup`` command, create a listening for the ``\Mautic\CoreBundle\CoreEvents::MAINTENANCE_CLEANUP_DATA`` event.
-The event listener should check if data should be deleted or a counted. Use ``$event->setStat($key, $affectedRows, $sql, $sqlParameters)`` to give feedback to the CLI command.
+To hook into the ``mautic:maintenance:cleanup`` command, create a listener for the ``\Mautic\CoreBundle\CoreEvents::MAINTENANCE_CLEANUP_DATA`` event.
+Use ``$event->setStat($key, $affectedRows, $sql, $sqlParameters)`` to give feedback to the CLI command.
 Note that ``$sql`` and ``$sqlParameters`` are only used for debugging and shown only in the ``dev`` environment.
 
-.. note:: The Plugin should verify if a dry run got requested using ``$event->isDryRun()`` before deleting records!
+.. warning:: Don't delete records when the event is a dry run. You can use ``$event->isDryRun()`` to validate whether this is the case. See the code sample below for more details.
 
 .. code-block:: php
 
-   <?php
+    <?php
     // plugins\HelloWorldBundle\EventListener\MaintenanceSubscriber.php
 
     declare(strict_types=1);

--- a/docs/components/maintenance.rst
+++ b/docs/components/maintenance.rst
@@ -1,4 +1,66 @@
-Maintenance
-###########
+Extending maintenance cleanup
+#############################
 
+To hook into the ``mautic:maintenance:cleanup`` command, create a listening for the ``\Mautic\CoreBundle\CoreEvents::MAINTENANCE_CLEANUP_DATA`` event.
+The event listener should check if data should be deleted or a counted. Use ``$event->setStat($key, $affectedRows, $sql, $sqlParameters)`` to give feedback to the CLI command.
+Note that ``$sql`` and ``$sqlParameters`` are only used for debugging and shown only in the ``dev`` environment.
 
+.. note:: The Plugin should verify if a dry run got requested using ``$event->isDryRun()`` before deleting records!
+
+.. code-block:: php
+
+   <?php
+    // plugins\HelloWorldBundle\EventListener\MaintenanceSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Doctrine\DBAL\Connection;
+    use Mautic\CoreBundle\CoreEvents;
+    use Mautic\CoreBundle\Event\MaintenanceEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Contracts\Translation\TranslatorInterface;
+
+    class MaintenanceSubscriber implements EventSubscriberInterface
+    {
+        protected Connection $db;
+        protected TranslatorInterface $translator;
+
+        public function __construct(Connection $db, TranslatorInterface $translator)
+        {
+            $this->db         = $db;
+            $this->translator = $translator;
+        }
+
+        public static function getSubscribedEvents()
+        {
+            return [
+                CoreEvents::MAINTENANCE_CLEANUP_DATA => ['onDataCleanup', -50]
+            ];
+        }
+
+        public function onDataCleanup(MaintenanceEvent $event)
+        {
+            $qb = $this->db->createQueryBuilder()
+                ->setParameter('date', $event->getDate()->format('Y-m-d H:i:s'));
+
+            if ($event->isDryRun()) {
+                $rows = (int) $qb->select('count(*) as records')
+                    ->from(MAUTIC_TABLE_PREFIX . 'worlds', 'w')
+                    ->where(
+                        $qb->expr()->gte('w.date_added', ':date')
+                    )
+                    ->execute()
+                    ->fetchColumn();
+            } else {
+                $rows = (int) $qb->delete(MAUTIC_TABLE_PREFIX . 'worlds')
+                    ->where(
+                        $qb->expr()->lte('date_added', ':date')
+                    )
+                    ->execute();
+            }
+
+            $event->setStat($this->translator->trans('mautic.maintenance.hello_world'), $rows, $qb->getSQL(), $qb->getParameters());
+        }
+    }


### PR DESCRIPTION
Closes #65

Also updated the Code Example as [the current one](https://developer.mautic.org/#extending-maintenance-cleanup) was severely outdated. It used `CommonSubscriber` which has been removed from Mautic a while ago.

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/94"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

