### PR TITLE
Add Mautic branding

### DIFF
--- a/docs/_static/tablefix.css
+++ b/docs/_static/tablefix.css
@@ -1,0 +1,14 @@
+/* override table width restrictions */
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}
+
+.wy-table-responsive {
+    margin-bottom: 24px;
+    max-width: 100%;
+    overflow: visible;
+}
+
+.wy-table-responsive th p {
+    margin-bottom: unset;
+}

--- a/docs/_static/theme.css
+++ b/docs/_static/theme.css
@@ -1,0 +1,15 @@
+.wy-side-nav-search, .wy-nav-side {
+    background-color: #4e5e9e;
+}
+
+.wy-menu-vertical p.caption {
+    color: #fdb933;
+}
+
+a {
+    color: #4e5e9e;
+}
+
+.wy-menu-vertical a, .wy-side-nav-search>a {
+    color: #ffffff;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,2 @@
+{% extends "!layout.html" %}
+{% set css_files = css_files + ["_static/tablefix.css"] + ["_static/theme.css"] %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ extensions = [
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+templates_path = ['_templates']
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -72,7 +73,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Please add links here that do not pass the "make checklinks" check.
 # A little context on the reason for ignoring is greatly appreciated!


### PR DESCRIPTION
Same as proposed for the end-user documentation, this adds the Mautic branding.

I also added the table fix which allows multi-line table rows - it's used extensively in the end-user docs but never made it this far!

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/103"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

