### PR TITLE
Bump Python version to 3.8

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,6 @@ sphinx:
 
 # Explicitly set the version of Python and its requirements
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
The latest Sphinx updates dropped support for Python 3.7, and while Gitpod builds are working fine, RTD builds have been failing as we have not updated the dependency in this config file.

There is not any way to test this with Gitpod as the file relates to the RTD configuration!