### PR TITLE
Fix "anchor not found" error

### DIFF
--- a/docs/links/excluded_by_default_autowiring.py
+++ b/docs/links/excluded_by_default_autowiring.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "excluded_directories" 
 link_text = "excluded by default" 
-link_url = "https://github.com/mautic/mautic/blob/HEAD/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php#L12" 
+link_url = "https://github.com/mautic/mautic/blob/HEAD/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php" 
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
CI was failing on the main branch with this error:

```
(plugins/autowiring: line  105) broken    https://github.com/mautic/mautic/blob/59aba68c9cf89e3c4a2e87f69b9669c9011961b6/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php#L12 - Anchor 'L12' not found
```

Let's remove the anchor, because the anchor doesn't seem to understand GitHub's anchor handling (which is slightly different than default HTML anchors)