### PR TITLE
REST API: Getting Started and Auth docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,9 +101,12 @@ This is a work in progress. More to come soon. In the meantime, go to :xref:`Leg
    :caption: REST API
    :hidden:
 
+   .. Added the "Getting Started" and "Authentication" docs to the top for better visibility
+
    rest_api/getting_started
-   rest_api/assets
    rest_api/authentication
+
+   rest_api/assets
    rest_api/campaigns
    rest_api/categories
    rest_api/companies

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,7 +101,9 @@ This is a work in progress. More to come soon. In the meantime, go to :xref:`Leg
    :caption: REST API
    :hidden:
 
+   rest_api/getting_started
    rest_api/assets
+   rest_api/authentication
    rest_api/campaigns
    rest_api/categories
    rest_api/companies

--- a/docs/links/symfony_api_cache.py
+++ b/docs/links/symfony_api_cache.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony Cache" 
+link_text = "Symfony Cache" 
+link_url = "https://symfony.com/doc/5.4/cache.html#configuring-cache-with-frameworkbundle" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/rest_api/authentication.rst
+++ b/docs/rest_api/authentication.rst
@@ -1,0 +1,292 @@
+Authentication
+##############
+
+Mautic supports OAuth2 or Basic Authentication for API authentication.
+
+Basic authentication
+********************
+
+To get started quickly with Mautic's API, you can use Basic Authentication.
+
+.. note::
+
+    Mautic recommends OAuth2 for security reasons. If you still want to use Basic Authentication, you must first enable it in ``Configuration -> API Settings`` in the Mautic UI, or by setting ``'api_enable_basic_auth' => true`` in ``app/config/local.php`` directly.
+
+After enabling Basic Authentication, you can use it in Mautic's API as follows:
+
+Using Mautic's API library
+==========================
+
+TODO
+
+Plain http requests
+===================
+
+1. Combine the username and password of a Mautic user with a colon ``:``. For example, ``user:password``.
+2. Base64 encode this value. For example, with ``echo -n 'user:password' | base64``. This outputs something like ``dXNlcjpwYXNzd29yZA==``.
+3. Add an Authorization header to each API request as ``Authorization: Basic dXNlcjpwYXNzd29yZA==``
+
+Here's an example:
+
+.. code-block:: console
+
+  curl -H "Authorization: Basic dXNlcjpwYXNzd29yZA==" https://mautic.example.com/api/contacts
+
+OAuth2
+******
+
+After enabling Mautic's API, the "API Credentials" menu item shows up in the administrator menu. You can create Client ID and Secret there, which you can then use in the next steps.
+
+.. note:: 
+
+    Mautic supports the ``authorization_code``, ``refresh_token`` and ``client_credentials`` grant types.
+
+There are two main flows that Mautic supports:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - Authorization code flow
+     - This flow is best if you want Users to log in with their own Mautic accounts. All actions taken will then be registered as if the user performed them in Mautic's UI.
+   * - Client Credentials flow
+     - This flow is best for Machine-to-Machine, M2M, communications. For example, in cron jobs or other automations where no humans are involved. All actions taken will be registered as XXXXXX.
+ 
+
+Authorization code flow 
+========================
+
+Using Mautic's API library
+--------------------------
+
+Mautic's API library has built-in support for the OAuth2 Authorization Code flow. You can use it as follows:
+
+.. code-block:: php
+
+   <?php
+   use Mautic\Auth\ApiAuth;
+
+   // $initAuth->newAuth() will accept an array of OAuth settings
+   $settings = array(
+       'baseUrl'      => 'https://example.mautic.com',
+       'version'      => 'OAuth2',
+       'clientKey'    => '5ad6fa7asfs8fa7sdfa6sfas5fas6asdf8', // A Client Key can be created in Mautic's UI through the "API Credentials" menu item
+       'clientSecret' => 'adf8asf7sf54asf3as4f5sf6asfasf97dd', // A Client Secret can be created in Mautic's UI through the "API Credentials" menu item
+       'callback'     => 'https://your-callback.com'
+   );
+
+   // Initiate the auth object
+   $initAuth = new ApiAuth();
+   $auth     = $initAuth->newAuth($settings);
+
+   // Initiate process for obtaining an access token; this will redirect the user to the authorize endpoint and/or set the tokens when the user is redirected back after granting authorization
+
+   if ($auth->validateAccessToken()) {
+       if ($auth->accessTokenUpdated()) {
+           $accessTokenData = $auth->getAccessTokenData();
+
+           //store access token data however you want
+       }
+   }
+
+Using plain OAuth2
+------------------
+
+.. note::
+
+   The OAuth processes can be tricky. If possible, it's best to use an OAuth library for the language being used. If you're using PHP, Mautic recommends using the :xref:`Mautic API Library`.
+
+Step one - obtain authorization code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Redirect the user to the authorize endpoint ``/oauth/v2/authorize``:
+
+.. code-block:: console
+
+    GET /oauth/v2/authorize?
+       client_id=CLIENT_ID
+       &grant_type=authorization_code
+       &redirect_uri=https%3A%2F%2Fyour-redirect-uri.com%2Fcallback
+       &response_type=code
+       &state=UNIQUE_STATE_STRING
+    
+    (note that the query has been wrapped for legibility)
+
+.. note:: 
+
+    The state is optional but recommended to prevent CSRF attacks. It should be a uniquely generated string and stored locally in session, cookie, etc. to be compared with the returned value.
+
+.. note:: 
+
+    Note that the redirect_uri should be URL encoded.
+
+The user will be prompted to login. Once they do, Mautic will redirect back to the URL specified in redirect_uri with a code appended to the query.
+
+It may look something like: `https://your-redirect-uri.com?code=UNIQUE_CODE_STRING&state=UNIQUE_STATE_STRING`
+
+The state returned should be compared against the original to ensure nothing has been tampered with. 
+
+Step two - replace with an access token
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Obtain the value of the code from Step One then immediately POST it back to the access token endpoint `oauth/v2/token` with:
+
+.. code-block:: console
+
+  POST /oauth/v2/token
+    ?client_id=CLIENT_ID
+    &client_secret=CLIENT_SECRET
+    &grant_type=authorization_code
+    &redirect_uri=https%3A%2F%2Fyour-redirect-uri.com%2Fcallback
+    &code=UNIQUE_CODE_STRING
+
+    (note that the post body has been wrapped for legibility)
+
+The response returned should be a JSON encoded string:
+
+.. code-block:: json
+
+    {
+        "access_token": "ACCESS_TOKEN",
+        "expires_in": 3600,
+        "token_type": "bearer",
+        "scope": "",
+        "refresh_token": "REFRESH_TOKEN"
+    }
+
+Please store this data in a secure location and use it to authenticate API requests.
+
+Refreshing tokens
+^^^^^^^^^^^^^^^^^
+
+The response's ``expires_in`` is the number of seconds the access token is good for and may differ based on what is configured in Mautic. The code handling the authorization process should generate an expiration timestamp based on that value. For example ``<?php $expiration = time() + $response['expires_in']; ?>``. If the access token has expired, the refresh_token should be used to obtain a new access token.
+
+By default, the refresh token is valid for 14 days.
+
+
+* If your application requests a new access token using the refresh token within 14 days, no user interaction is needed. Your application gets both a new access token and a new refresh token (which is valid for another 14 days after it's issued);
+* If your application does not request a new token using the refresh token within 14 days, user interaction is required in order to get new tokens.
+
+The refresh token's expiration time is configurable through Mautic's Configuration. 
+
+.. note:: 
+    The application should monitor for a ``400 Bad Request`` response when requesting a new access token and redirect the user back through the authorization process.
+
+
+To obtain a new access token, a POST should be made to the access token's endpoint ``oauth/v2/token`` using the ``refresh_token`` grant type.
+
+.. code-block:: console
+
+    POST /oauth/v2/token
+       ?client_id=CLIENT_ID
+       &client_secret=CLIENT_SECRET
+       &grant_type=refresh_token
+       &refresh_token=REFRESH_TOKEN
+       &redirect_uri=https%3A%2F%2Fyour-redirect-uri.com%2Fcallback
+
+    (note that the post body has been wrapped for legibility)
+
+The response returned should be a JSON encoded string:
+
+.. code-block:: json
+
+    {
+        "access_token": "NEW_ACCESS_TOKEN",
+        "expires_in": 3600,
+        "token_type": "bearer",
+        "scope": "",
+        "refresh_token": "REFRESH_TOKEN"
+    }
+
+Client credentials flow
+=======================
+
+Using Mautic's API library
+--------------------------
+
+Mautic's API library has built-in support for the OAuth2 Client Credentials flow. You can use it as follows:
+
+.. code-block:: php
+
+   <?php
+   use Mautic\Auth\ApiAuth;
+
+   // $initAuth->newAuth() will accept an array of OAuth settings
+   $settings = array(
+       'baseUrl'      => 'https://example.mautic.com',
+       'version'      => 'OAuth2',
+       'clientKey'    => '5ad6fa7asfs8fa7sdfa6sfas5fas6asdf8', // A Client Key can be created in Mautic's UI through the "API Credentials" menu item
+       'clientSecret' => 'adf8asf7sf54asf3as4f5sf6asfasf97dd', // A Client Secret can be created in Mautic's UI through the "API Credentials" menu item
+       'callback'     => 'https://your-callback.com'
+   );
+
+   // Initiate the auth object
+   $initAuth = new ApiAuth();
+   $auth     = $initAuth->newAuth($settings);
+
+   // Initiate process for obtaining an access token; this will redirect the user to the authorize endpoint and/or set the tokens when the user is redirected back after granting authorization
+
+   if ($auth->validateAccessToken()) {
+       if ($auth->accessTokenUpdated()) {
+           $accessTokenData = $auth->getAccessTokenData();
+
+           //store access token data however you want
+       }
+   }
+
+Using plain OAuth2
+------------------
+
+To obtain a new access token, a POST should be made to the access token's endpoint ``oauth/v2/token`` using the ``client_credentials`` grant type.
+
+.. code-block:: console
+
+    POST /oauth/v2/token
+      ?client_id=CLIENT_ID
+      &client_secret=CLIENT_SECRET
+      &grant_type=client_credentials
+
+    (note that the post body has been wrapped for legibility)
+
+The response returned should be a JSON encoded string:
+
+.. code-block:: json
+
+    {
+        "access_token": "NEW_ACCESS_TOKEN",
+        "expires_in": 3600,
+        "token_type": "bearer",
+        "scope": ""
+    }
+
+Authenticating the API Request
+==============================
+
+Authenticating the API request with OAuth2 is easy. Choose one of the following methods that is appropriate for the application's needs.
+
+Authorization Header
+--------------------
+
+By using an authorization header, any request method can be authenticated.
+
+However, note that this method requires that the server Mautic is installed on passes headers to PHP or has access to the ``apache_request_headers()`` function. ``apache_request_headers()`` is not available to PHP running under fcgi. 
+
+.. code-block:: console
+
+    Authorization: Bearer ACCESS_TOKEN
+
+Other methods
+-------------
+
+You can also append the access token to the query or include it the POST body.
+
+.. code-block:: console
+    
+    GET https://your-mautic.com/api/leads?access_token=ACCESS_TOKEN
+
+.. code-block:: console
+    
+    POST https://your-mautic.com/api/leads/new
+
+    firstname=John&lastname=Smith&access_token=ACCESS_TOKEN

--- a/docs/rest_api/authentication.rst
+++ b/docs/rest_api/authentication.rst
@@ -51,7 +51,7 @@ Plain HTTP requests
 
 .. vale on
 
-1. Combine the username and password of a Mautic user with a colon ``:``. For example, ``user:password``.
+1. Combine the username and password of a Mautic User with a colon ``:``. For example, ``user:password``.
 2. Base64 encode this value. For example, with ``echo -n 'user:password' | base64``. This outputs something like ``dXNlcjpwYXNzd29yZA==``.
 3. Add an Authorization header to each API request as ``Authorization: Basic dXNlcjpwYXNzd29yZA==``
 
@@ -190,7 +190,7 @@ Please store this data in a secure location and use it to authenticate API reque
 Refreshing tokens
 ^^^^^^^^^^^^^^^^^
 
-The response's ``expires_in`` is the number of seconds the access token is good for and may differ based on what you configured in Mautic. The code handling the authorization process should generate an expiration timestamp based on that value. For example ``<?php $expiration = time() + $response['expires_in']; ?>``. If the access token has expired, the ``refresh_token`` should be used to obtain a new access token.
+The response's ``expires_in`` is the number of seconds the access token is good for and may differ based on what you configured in Mautic. The code handling the authorization process should generate an expiration timestamp based on that value. For example ``<?php $expiration = time() + $response['expires_in']; ?>``. If the access token has expired, you can use the ``refresh_token`` to obtain a new access token.
 
 By default, the refresh token is valid for 14 days unless configured otherwise in Mautic.
 

--- a/docs/rest_api/getting_started.rst
+++ b/docs/rest_api/getting_started.rst
@@ -19,7 +19,7 @@ Mautic supports Basic Authentication and OAuth2. Please see :ref:`Authentication
 Error handling
 **************
 
-If an OAuth error is encountered, it'll be a JSON encoded array similar to:
+In case of OAuth errors, the response is a JSON encoded array similar to:
 
 .. code-block:: json
 
@@ -28,7 +28,7 @@ If an OAuth error is encountered, it'll be a JSON encoded array similar to:
         "error_description": "The access token provided has expired."
    }
 
-If a system error encountered, it'll be a JSON encoded array similar to:
+In case of system errors, the response is a JSON encoded array similar to:
 
 .. code-block:: json
 
@@ -39,12 +39,16 @@ If a system error encountered, it'll be a JSON encoded array similar to:
        }
    }
 
+.. vale off
+
 Mautic version check
 ********************
 
-In case your API service wants to support several Mautic versions with different features, you might need to check the version of Mautic you communicate with. Since Mautic 2.4.0 the version number is added to all API response headers. The header name is ``Mautic-Version``.
+.. vale on
 
-With Mautic's PHP API library you can get the Mautic version like this:
+In case your API service wants to support several Mautic versions with different features, you might need to validate the version of Mautic you communicate with. Since Mautic 2.4.0, the version number is in all API response headers. The header name is ``Mautic-Version``.
+
+With Mautic's PHP API library, you can get the Mautic version like this:
 
 .. code-block:: php
 
@@ -57,37 +61,34 @@ With Mautic's PHP API library you can get the Mautic version like this:
     // Get the version number from the response header:
     $version = $api->getMauticVersion();
 
-``$version`` will be in a semantic versioning format: ``[major].[minor].[patch]``. For example: ``2.4.0``. If you'll try it on the latest GitHub version, the version will have ``-dev`` at the end. Like ``2.5.1-dev``.
+``$version`` is in a semantic versioning format: ``[major].[minor].[patch]``. For example: ``2.4.0``. If you'll try it on the latest GitHub version, the version has ``-dev`` at the end. Like ``2.5.1-dev``.
 
+.. vale off
 
-API Rate limiter
-****************
+API Rate limiter cache
+**********************
 
-You can configure rate limiter cache in ``local.php``
-By default, filesystem is used as:
+.. vale on
+
+You can configure rate limiter cache in ``config/local.php``, which defaults to the filesystem:
 
 .. code-block:: php
 
     <?php
-    api_rate_limiter_cache => [ 
-        'type'      => 'file_system',
+
+    'api_rate_limiter_cache' => [ 
+        'adapter' => 'cache.adapter.filesystem',
     ],
 
-You can configure memcached server:
+You can also configure a ``memcached`` server for improved performance, like this:
 
 .. code-block:: php
 
     <?php
-    'api_rate_limiter_cache' => [
-        'memcached' => [
-            'servers' =>
-            [
-                [
-                'host' => 'localhost',
-                'port' => 11211
-                ]
-            ]
-        ]
-        ],
 
-Or whatever cache you want described in `Symfony cache documentation <https://symfony.com/doc/current/bundles/DoctrineCacheBundle/reference.html>`_.
+    'api_rate_limiter_cache' => [
+        'adapter'  => 'cache.adapter.memcached',
+        'provider' => 'memcached://memcached.local:12345'
+    ],
+
+For more examples of supported cache adapters, please visit the :xref:`Symfony Cache Documentation<Symfony Cache>`.

--- a/docs/rest_api/getting_started.rst
+++ b/docs/rest_api/getting_started.rst
@@ -11,6 +11,11 @@ Mautic provides several ``REST API`` endpoints that you can use. In the navigati
 
     Mautic has an API library available for PHP. You can :xref:`find it on GitHub<Mautic API Library>`.
 
+To get started easily, you can use Mautic's Postman collection:
+
+.. image:: https://run.pstmn.io/button.svg
+   :target: https://app.getpostman.com/run-collection/19345380-9b7bbddc-8a4d-437a-8fc2-42b0b9823883?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D19345380-9b7bbddc-8a4d-437a-8fc2-42b0b9823883%26entityType%3Dcollection%26workspaceId%3D2c328b62-2531-4e35-a6bc-0f2995ce2df3
+
 Authentication
 **************
 

--- a/docs/rest_api/getting_started.rst
+++ b/docs/rest_api/getting_started.rst
@@ -1,0 +1,93 @@
+Getting started
+###############
+
+Mautic provides several ``REST API`` endpoints that you can use. In the navigation menu on the left, you can find the available endpoints.
+
+.. warning:: 
+
+    By default, Mautic's ``REST API`` isn't enabled. The Mautic administrator can enable the API in the Mautic UI under ``Configuration -> API Settings``, or by setting ``'api_enabled' => 1`` in ``app/config/local.php`` directly.
+
+.. note:: 
+
+    Mautic has an API library available for PHP. You can :xref:`find it on GitHub<Mautic API Library>`.
+
+Authentication
+**************
+
+Mautic supports Basic Authentication and OAuth2. Please see :ref:`Authentication` for more details.
+
+Error handling
+**************
+
+If an OAuth error is encountered, it'll be a JSON encoded array similar to:
+
+.. code-block:: json
+
+    {
+        "error": "invalid_grant",
+        "error_description": "The access token provided has expired."
+   }
+
+If a system error encountered, it'll be a JSON encoded array similar to:
+
+.. code-block:: json
+
+    {
+       "error": {
+           "message": "You do not have access to the requested area/action.",
+           "code": 403
+       }
+   }
+
+Mautic version check
+********************
+
+In case your API service wants to support several Mautic versions with different features, you might need to check the version of Mautic you communicate with. Since Mautic 2.4.0 the version number is added to all API response headers. The header name is ``Mautic-Version``.
+
+With Mautic's PHP API library you can get the Mautic version like this:
+
+.. code-block:: php
+
+    <?php
+
+    // Make any API request:
+    $api = $this->getContext('contacts');
+    $response = $api->getList('', 0, 1);
+
+    // Get the version number from the response header:
+    $version = $api->getMauticVersion();
+
+``$version`` will be in a semantic versioning format: ``[major].[minor].[patch]``. For example: ``2.4.0``. If you'll try it on the latest GitHub version, the version will have ``-dev`` at the end. Like ``2.5.1-dev``.
+
+
+API Rate limiter
+****************
+
+You can configure rate limiter cache in ``local.php``
+By default, filesystem is used as:
+
+.. code-block:: php
+
+    <?php
+    api_rate_limiter_cache => [ 
+        'type'      => 'file_system',
+    ],
+
+You can configure memcached server:
+
+.. code-block:: php
+
+    <?php
+    'api_rate_limiter_cache' => [
+        'memcached' => [
+            'servers' =>
+            [
+                [
+                'host' => 'localhost',
+                'port' => 11211
+                ]
+            ]
+        ]
+        ],
+
+Or whatever cache you want described in `Symfony cache documentation <https://symfony.com/doc/current/bundles/DoctrineCacheBundle/reference.html>`_.


### PR DESCRIPTION
This is a really important section of the REST API docs as they're the "entrypoint" to those docs. I tried making everything as clear and easy-to-follow as possible, but please let me know if you see room for improvements (or just commit changes yourself).

Differences compared to the [old docs](https://developer.mautic.org/#authorization):
- Removed OAuth1a section as support for it [was removed in Mautic 4](https://github.com/mautic/mautic/pull/10111).
- Updated the API Rate Limiter docs as [its config structure was changed in Mautic 3](https://github.com/mautic/mautic/blob/c86f0eebf36fa78fa40e44491f021a0806b3ee6b/UPGRADE-3.0.md?plain=1#L48)
- Improved Basic Auth instructions (including an example with Mautic's API library) to help users get started with Mautic's API more quickly
- Improved OAuth2 section (e.g. added actual `curl` commands that devs can copy/paste for easy testing) and tested all flows to make sure they still work against Mautic 4
- Several textual and formatting-related improvements