### PR TITLE
GitHub Actions: update Actions versions

### DIFF
--- a/.github/workflows/dev_merge_pr.yml
+++ b/.github/workflows/dev_merge_pr.yml
@@ -10,14 +10,14 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 'Checkout development'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: development
           fetch-depth: 0
           token: ${{ secrets.MAUTIBOT_PAT }}
 
       - name: 'Download approved PR number'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/dev_validate_pr.yml
+++ b/.github/workflows/dev_validate_pr.yml
@@ -6,11 +6,11 @@ jobs:
   merge-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: 'Prevent merging into development if the PR is not approved'
         if: github.event.review.state != 'approved'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('The PR is not approved to be merged into development')
@@ -21,7 +21,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} > ./pr/NR
       - name: 'Store the PR number if approved'
         if: github.event.review.state == 'approved'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
         cache: 'pip'

--- a/docs/plugins/continuous-integration.rst
+++ b/docs/plugins/continuous-integration.rst
@@ -60,13 +60,13 @@ This file creates the GitHub Action jobs based on the definitions in it. You can
 
       steps:
       - name: Checkout Mautic 4
-         uses: actions/checkout@v3
+         uses: actions/checkout@v4
          with:
          repository: mautic/mautic
          ref: ${{ matrix.mautic-versions }}
 
       - name: Checkout this plugin
-         uses: actions/checkout@v3
+         uses: actions/checkout@v4
          with:
          path: ${{ env.PLUGIN_DIR }}
 


### PR DESCRIPTION
The current versions have been out of support for a long time and are triggering warnings in the CI pipelines. Let's update them!