### PR TITLE
Update Vale to latest

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ jobs:
       uses: errata-ai/vale-action@reviewdog
       with:
         # Please keep version in sync with the version in .gitpod.Dockerfile for a consistent experience
-        version: 2.20.2
+        version: 2.28.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.10
 
-# Don't update to a higher version until this issue has been fixed: https://github.com/errata-ai/vale/issues/528
 # Please keep version in sync with the version in .github/workflows/linting.yml for a consistent experience
-ENV VALE_VERSION=2.20.2
+ENV VALE_VERSION=2.28.3
 
 WORKDIR /workspace
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11
 
 # Please keep version in sync with the version in .github/workflows/linting.yml for a consistent experience
 ENV VALE_VERSION=2.28.3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "esbonio.sphinx.confDir": "${workspaceFolder}/docs",
     "restructuredtext.pythonRecommendation.disabled": true,
     "restructuredtext.preview.name": "sphinx",
-    "gitlens.showWhatsNewAfterUpgrades": false
+    "gitlens.showWhatsNewAfterUpgrades": false,
+    "restructuredtext.linter.rstcheck.executablePath": "rstcheck"
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,9 +4,9 @@
 sphinx==6.2.1
 sphinx_rtd_theme==1.2.0
 readthedocs-sphinx-search==0.3.1
-rstcheck==6.1.1
+rstcheck==6.2.0
 myst-parser==1.0.0 
 linkify-it-py==2.0.0
-esbonio==0.15.0
+esbonio==0.16.1
 attrs==22.2.0
 


### PR DESCRIPTION
We're quite a few versions behind. Let's go from 2.20.2 (Sept 14 2022) to 2.28.3. Changelog: https://github.com/errata-ai/vale/releases

This also fixes the Gitpod/VS Code integration by bumping the Esbonio language server to the latest version 🚀 

<img width="1917" alt="image" src="https://github.com/mautic/developer-documentation-new/assets/17739158/65c6e99b-dedf-4203-a8fd-1df4d5e42f31">

<a href="https://gitpod.io/#https://github.com/mautic/developer-documentation-new/pull/155"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

