### PR TITLE
Update landing page - 5.x

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,44 @@ Welcome to Mautic's developer documentation
 ===========================================
 
 .. note::
-    We are still working on bringing over some of the content from our old documentation, which you can find at [https://developer.mautic.org](https://developer.mautic.org). Please see the issue queue if you'd like to help with completing this work.
+    Work is ongoing bringing over some of the content from the old documentation, which you can find at :xref:`Mautic Developer Portal`. Please see the :xref:`Mautic Dev Docs Issues` if you'd like to help with completing this work.
+
+Welcome to the Mautic Developer Documentation. The documentation broadly covers building custom Plugins for Mautic which extends its features, building custom Themes, and how to integrate applications outside of Mautic using the REST API.
+
+This documentation has multiple versions for different releases of Mautic starting from Mautic 4.x - the switcher is in the bottom left which allows you to change between versions.
+
+Submitting code to Mautic
+*************************
+
+Development is open and available to any member of the Mautic community. All fixes and improvements happen through pull requests to the code on :xref:`Mautic's GitHub Repo`. This code is open source and publicly available.
+
+Read all about contributing to Mautic as a Developer in the :xref:`Mautic Developer Contribution Guide`.
+
+Read more about Mautic's :xref:`Mautic Code Governance` and the :xref:`Mautic Project Governance` model.
+
+Your code must follow the :xref:`Symfony coding standards`. You will find details about where Mautic deviates from these standards documented in the :doc:`/plugins/mautic_vs_symfony` section.
+
+Where to get help
+*****************
+
+The first place to ask for support is on the :xref:`Developer Forum` - this is where the Product Team monitors, and where most developers look out for posts they can assist with. There is also a Commercial forum if you have paid opportunities or are looking for work.
+
+General development chatter also happens in ``#dev`` on :xref:`Mautic Slack`, and anything to do with contributing - including the weekly Open Source Friday contribution sprints - happen in ``#t-product``.
+
+New major releases also have a dedicated space for discussion - for example ``#mautic-5`` and ``#mautic-6``.
+
+Several areas on the Community Portal could be of interest, including :xref:`Community Portal Roadmap` and the :xref:`Community Portal Product Team`.
+
+Supporting Mautic
+*****************
+
+There are several ways to support Mautic other than contributing with code.
+
+1. Help with testing bugs and features using Gitpod in the browser - head to the :xref:`Mautic Tester Docs`
+2. Help with improving the documentation on this site, and the :xref:`Mautic End User Docs`.
+3. :xref:`Contribute to Mautic` with other skills
+4. Become a :xref:`Become a Member of Mautic`
+5. Support Mautic on :xref:`Open Collective`
 
 .. toctree::
    :maxdepth: 2
@@ -114,6 +151,6 @@ Welcome to Mautic's developer documentation
 Indices and tables
 ==================
 
-* :ref:`genindex`
+* :ref:`genindex` 
 * :ref:`modindex`
 * :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,8 @@
 Welcome to Mautic's developer documentation
 ===========================================
 
-This is a work in progress. More to come soon. In the meantime, go to :xref:`Legacy Developer Docs` to view the developer documentation.
+.. note::
+    We are still working on bringing over some of the content from our old documentation, which you can find at [https://developer.mautic.org](https://developer.mautic.org). Please see the issue queue if you'd like to help with completing this work.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/links/mautic_become_a_member.py
+++ b/docs/links/mautic_become_a_member.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Become a Member of Mautic" 
+link_text = "Member of Mautic" 
+link_url = "https://mautic.org/become-a-member-of-mautic" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_code_governance.py
+++ b/docs/links/mautic_code_governance.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Code Governance" 
+link_text = "code governance" 
+link_url = "https://contribute.mautic.org/governance/code-governance" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_contribution_docs.py
+++ b/docs/links/mautic_contribution_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Contribute to Mautic" 
+link_text = "Contributing to Mautic" 
+link_url = "https://mau.tc/contribute" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_dev_contribution_guide.py
+++ b/docs/links/mautic_dev_contribution_guide.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Developer Contribution Guide" 
+link_text = "Mautic Developer Contribution Guide" 
+link_url = "https://contribute.mautic.org/contributing-to-mautic/developer" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_dev_portal.py
+++ b/docs/links/mautic_dev_portal.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Developer Portal" 
+link_text = "https://developer.mautic.org" 
+link_url = "https://developer.mautic.org" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_devdocs_issues.py
+++ b/docs/links/mautic_devdocs_issues.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Dev Docs Issues" 
+link_text = "developer documentation issue queue" 
+link_url = "https://github.com/mautic/developer-documentation-new/issues" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_end_user_docs.py
+++ b/docs/links/mautic_end_user_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic End User Docs" 
+link_text = "end-user documentation" 
+link_url = "https://docs.mautic.org" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_open_collective.py
+++ b/docs/links/mautic_open_collective.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Open Collective" 
+link_text = "Open Collective" 
+link_url = "https://opencollective.com/mautic" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_portal_product_team.py
+++ b/docs/links/mautic_portal_product_team.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Community Portal Product Team" 
+link_text = "Product Team Assembly" 
+link_url = "https://community.mautic.org/assemblies/product-team" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_portal_roadmap.py
+++ b/docs/links/mautic_portal_roadmap.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Community Portal Roadmap" 
+link_text = "proposals for new major features" 
+link_url = "https://community.mautic.org/processes/roadmap" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_project_governance.py
+++ b/docs/links/mautic_project_governance.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Project Governance" 
+link_text = "Mautic Project Governance" 
+link_url = "https://contribute.mautic.org/governance/governance" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_tester_docs.py
+++ b/docs/links/mautic_tester_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Tester Docs" 
+link_text = "Tester Documentation" 
+link_url = "https://mau.tc/tester" 
+
+link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
This PR updates the landing page for the 5.x branch.

It adds some info from the current docs, and also signposts people to the relevant resources to get help.

Fixes #157 