### PR TITLE
Update Read the Docs config file to prevent build failing

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
-# Build from the docs/ directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
 
-# Explicitly set the version of Python and its requirements
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: 3.8
-  install:
-    - requirements: docs/requirements.txt
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
RTD have updated their specs and the config file now needs a lot more options.

This will get the build working again, all being well!