### PR TITLE
Bump Sphinx RTD Search

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@
 # Defining the exact version will make sure things don't break
 sphinx==6.2.1
 sphinx_rtd_theme==1.2.0
-readthedocs-sphinx-search==0.3.1
+readthedocs-sphinx-search==0.3.2
 rstcheck==6.1.1
 myst-parser==1.0.0 
 linkify-it-py==2.0.0


### PR DESCRIPTION
Per the advisory here: https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj we need to update this plugin.