### PR TITLE
Fix RST syntax errors

### DIFF
--- a/docs/components/campaigns.rst
+++ b/docs/components/campaigns.rst
@@ -18,21 +18,21 @@ Mautic dispatches the Event ``\Mautic\CampaignBundle\CampaignEvents::CAMPAIGN_ON
   .. php:method:: public addAction(string $key, array $action)
 
       :param string $key: Unique key for the Action.
-      :param array $action: :ref:`Action definition<Campaign Action definition>`.
+      :param array $action: :ref:`Campaign definition <components/campaigns:Campaign Action definition>`.
 
       :returntype: void
 
   .. php:method:: public addCondition(string $key, array $condition)
 
       :param string $key: Unique key for the Condition.
-      :param array $condition: :ref:`Condition definition<Campaign Condition definition>`.
+      :param array $condition: :ref:`Condition definition <components/campaigns:Campaign Condition definition>`.
 
       :returntype: void
 
   .. php:method:: public addDecision(string $key, array $decision)
 
       :param string $key: Unique key for the Decision.
-      :param array $decision: :ref:`Decision definition<Campaign Decision definition>`.
+      :param array $decision: :ref:`Decision definition <components/campaigns:Campaign Decision definition>`.
 
       :returntype: void
 

--- a/docs/components/campaigns.rst
+++ b/docs/components/campaigns.rst
@@ -18,7 +18,7 @@ Mautic dispatches the Event ``\Mautic\CampaignBundle\CampaignEvents::CAMPAIGN_ON
   .. php:method:: public addAction(string $key, array $action)
 
       :param string $key: Unique key for the Action.
-      :param array $action: :ref:`Campaign definition <components/campaigns:Campaign Action definition>`.
+      :param array $action: :ref:`Action definition <components/campaigns:Campaign Action definition>`.
 
       :returntype: void
 

--- a/docs/components/campaigns.rst
+++ b/docs/components/campaigns.rst
@@ -10,43 +10,46 @@ Registering Campaign Events
 
 Mautic dispatches the Event ``\Mautic\CampaignBundle\CampaignEvents::CAMPAIGN_ON_BUILD`` for Plugins to register their Campaign Actions, Conditions and Decisions. Listeners receive a ``Mautic\CampaignBundle\Events\CampaignBuilderEvent`` object. Register the Event using the appropriate ``add`` method as described below.
 
-.. php:class:: Mautic\CampaignBundle\Events\CampaignBuilderEvent
+.. php:namespace:: Mautic\CampaignBundle\Events
+.. php:class:: CampaignBuilderEvent
 
-.. php:method:: public addAction(string $key, array $action)
+  CampaignBuilderEvent class
 
-    :param string $key: Unique key for the Action.
-    :param array $action: :ref:`Action definition<Campaign Action definition>`.
+  .. php:method:: public addAction(string $key, array $action)
 
-    :returntype: void
+      :param string $key: Unique key for the Action.
+      :param array $action: :ref:`Action definition<Campaign Action definition>`.
 
-.. php:method:: public addCondition(string $key, array $condition)
+      :returntype: void
 
-    :param string $key: Unique key for the Condition.
-    :param array $condition: :ref:`Condition definition<Campaign Condition definition>`.
+  .. php:method:: public addCondition(string $key, array $condition)
 
-    :returntype: void
+      :param string $key: Unique key for the Condition.
+      :param array $condition: :ref:`Condition definition<Campaign Condition definition>`.
 
-.. php:method:: public addDecision(string $key, array $decision)
+      :returntype: void
 
-    :param string $key: Unique key for the Decision.
-    :param array $decision: :ref:`Decision definition<Campaign Decision definition>`.
+  .. php:method:: public addDecision(string $key, array $decision)
 
-    :returntype: void
+      :param string $key: Unique key for the Decision.
+      :param array $decision: :ref:`Decision definition<Campaign Decision definition>`.
 
-.. php:method:: public getActions()
+      :returntype: void
 
-    :return: Array of registered Actions.
-    :returntype: array
+  .. php:method:: public getActions()
 
-.. php:method:: public getConditions()
+      :return: Array of registered Actions.
+      :returntype: array
 
-    :return: Array of registered Conditions.
-    :returntype: array
+  .. php:method:: public getConditions()
 
-.. php:method:: public getDecisions()
+      :return: Array of registered Conditions.
+      :returntype: array
 
-    :return: Array of registered Decisions.
-    :returntype: array
+  .. php:method:: public getDecisions()
+
+      :return: Array of registered Decisions.
+      :returntype: array
 
 .. vale off
 

--- a/docs/components/contacts.rst
+++ b/docs/components/contacts.rst
@@ -172,7 +172,7 @@ Contact timeline/history
 To inject events into a Contact's timeline, create an event listener that listens to the ``LeadEvents::TIMELINE_ON_GENERATE`` event.
 Using this event, the Plugin can inject unique items into the timeline and also into the engagements graph on each page.
 
-.. note:: Before using this event listener, you'll need to ensure that you store your custom events in a custom database table. See :ref:`Generating timeline events from your own custom events` below for more details.
+.. note:: Before using this event listener, you'll need to ensure that you store your custom events in a custom database table. See :ref:`components/contacts:Generating timeline events from your own custom events` below for more details.
 
 The event listener receives a ``Mautic\LeadBundle\Event\LeadTimelineEvent`` object. You can find the commonly used methods below the code example.
 

--- a/docs/components/emails.rst
+++ b/docs/components/emails.rst
@@ -437,7 +437,7 @@ This section is in progress. See  ``\Mautic\EmailBundle\Stats\Helper\StatHelperI
 .. vale off
 
 Testing Email transports
-########################
+************************
 
 .. vale on
   

--- a/docs/components/forms_advanced.rst
+++ b/docs/components/forms_advanced.rst
@@ -18,7 +18,7 @@ Custom Form types
 
 As stated in Symfony's documentation as referenced in the preceding section, Form type classes are the best way to go.
 Mautic makes it easy to register :xref:`Form type services<Symfony 4 custom Form field type>` through the bundle's config file.
-Refer to the :ref:`Service config items` section.
+Refer to the :ref:`plugins/config:Service config items` section.
 
 Data sanitizing
 ***************

--- a/docs/components/integrations.rst
+++ b/docs/components/integrations.rst
@@ -93,9 +93,9 @@ Integration authentication
 
 If the Integration requires authentication with the third party service:
 
-1. :ref:`Register the Integration<Register the Integration for Authentication>` as an Integration that requires authentication options.
-2. Create a custom Symfony Form type for the required credentials and return it as part of the :ref:`config interface<ConfigFormAuthInterface>`.
-3. Create a custom service that builds and configures the Guzzle client required to authenticate and communicate with the third party service. Use an :ref:`existing supported factory or create a new one<Authentication Providers>`.
+1. :ref:`Register the Integration<components/integrations_authentication:Register the Integration for Authentication>` as an Integration that requires authentication options.
+2. Create a custom Symfony Form type for the required credentials and return it as part of the :ref:`config interface<components/integrations_configuration:ConfigFormAuthInterface>`.
+3. Create a custom service that builds and configures the Guzzle client required to authenticate and communicate with the third party service. Use an :ref:`existing supported factory or create a new one<components/integrations_authentication:Authentication Providers>`.
 
 Integration configuration
 *************************
@@ -103,8 +103,8 @@ Integration configuration
 
 If the Integration has extra configuration settings for features unique to it:
 
-1. :ref:`Register the Integration<Register the Integration for configuration>` as an Integration that requires configuration options.
-2. Create a custom Symfony Form type for the features and return it as part of the :ref:`Config Form feature setting interface<ConfigFormFeatureSettingsInterface>`.
+1. :ref:`Register the Integration<components/integrations_configuration:Register the Integration for configuration>` as an Integration that requires configuration options.
+2. Create a custom Symfony Form type for the features and return it as part of the :ref:`Config Form feature setting interface<components/integrations_configuration:ConfigFormFeatureSettingsInterface>`.
 
 .. vale off
 
@@ -115,7 +115,7 @@ Integration sync engine
 
 If the Integration syncs with Mautic's Contacts and/or Companies:
 
-1. Read about :ref:`the sync engine<Sync engine>`.
+1. Read about :ref:`the sync engine<components/integrations_sync:Sync engine>`.
 
 .. vale off
 
@@ -126,5 +126,5 @@ Integration Builders
 
 If the Integration includes a Builder, Email, or Landing Page:
 
-1. :ref:`Register the Integration<Register the Integration as a builder>` as an Integration that provides a custom builder.
+1. :ref:`Register the Integration<components/integrations_builder:Register the Integration as a builder>` as an Integration that provides a custom builder.
 2. Configure what featured builders the Integration supports (Mautic currently supports 'Email' and 'Landing Page' builders).

--- a/docs/components/integrations_authentication.rst
+++ b/docs/components/integrations_authentication.rst
@@ -666,7 +666,7 @@ OAuth2 three legged
 
 Three legged OAuth2 with the code grant is the most complex to implement because it involves redirecting the User to the third party service to authenticate then sent back to Mautic to initiate the access token process using a code returned in the request.
 
-The first step is to register the Integration as a :ref:`\\Mautic\\IntegrationsBundle\\Integration\\Interfaces\\AuthenticationInterface<Register the Integration for Authentication>`.
+The first step is to register the Integration as a :ref:`\\Mautic\\IntegrationsBundle\\Integration\\Interfaces\\AuthenticationInterface<components/integrations_authentication:Register the Integration for Authentication>`.
 The ``authenticateIntegration()`` method initiates the access token process using the ``code`` returned in the request after the User logs into the third-party service.
 
 .. vale off
@@ -703,7 +703,7 @@ This redirect URI can display in the UI by using :xref:`ConfigFormCallbackInterf
     }
 
 The trick here is that the ``Client``'s ``authenticate`` method configures a ``ClientInterface`` and then calls any valid API URL.
-The middleware initiates the access token process by making a call and storing it in the ``Integration`` entity's API keys through :ref:`TokenPersistenceFactory<Token Persistence>`.
+The middleware initiates the access token process by making a call and storing it in the ``Integration`` entity's API keys through :ref:`TokenPersistenceFactory<components/integrations_authentication:Token Persistence>`.
 Mautic recommends keeping the URL simple, like a checking version or fetching info for the authenticated User.
 
 Here is an example of a client, assuming that the User has already logged in and the code is in the request.

--- a/docs/components/integrations_configuration.rst
+++ b/docs/components/integrations_configuration.rst
@@ -110,7 +110,7 @@ Enabled/auth tab
 
 .. vale on
 
-These interfaces provide the configuration options for authenticating with the third party service. Read more about how to use IntegrationsBundle's  :ref:`auth providers here<Authentication Providers>`.
+These interfaces provide the configuration options for authenticating with the third party service. Read more about how to use IntegrationsBundle's  :ref:`auth providers here<components/integrations_authentication:Authentication Providers>`.
 
 
 .. vale off

--- a/docs/components/integrations_configuration_form_notes.rst
+++ b/docs/components/integrations_configuration_form_notes.rst
@@ -18,17 +18,17 @@ The ``ConfigSupport`` class should implement the ``\Mautic\IntegrationsBundle\In
 .. php:method:: public function getAuthorizationNote(): ?Note
 
     :return: The message and type for Auth tab.
-    :returntype: :ref:`Note<Note Object>`
+    :returntype: :ref:`Note<components/integrations_configuration_form_notes:Note Object>`
 
 .. php:method:: public function getFeaturesNote(): ?Note
 
     :return: The message and type for Features tab.
-    :returntype: :ref:`Note<Note Object>`
+    :returntype: :ref:`Note<components/integrations_configuration_form_notes:Note Object>`
 
 .. php:method:: public function getFieldMappingNote(): ?Note
 
     :return: The message and type for Field Mapping tab.
-    :returntype: :ref:`Note<Note Object>`
+    :returntype: :ref:`Note<components/integrations_configuration_form_notes:Note Object>`
 
 _____
 

--- a/docs/components/landing_pages.rst
+++ b/docs/components/landing_pages.rst
@@ -5,7 +5,7 @@ There are two way to extend Landing Pages:
 - Landing Page tokens used to insert Dynamic Content into a Landing Page
 - A/B test winning criteria
 
-Both leverage the ``\Mautic\PageBundle\PageEvents::PAGE_ON_BUILD`` event. Read more about :ref:`Event listeners`.
+Both leverage the ``\Mautic\PageBundle\PageEvents::PAGE_ON_BUILD`` event. Read more about :ref:`plugins/event_listeners:Event listeners`.
 
 .. vale off
 
@@ -14,14 +14,14 @@ Landing Page tokens
 
 .. vale on
 
-Landing Page tokens get handled exactly the same as :ref:`Email tokens<Email tokens and A/B testing>`.
+Landing Page tokens get handled exactly the same as :ref:`Email tokens<components/emails:Email tokens and A/B testing>`.
 
 .. vale off
 
 Page A/B Test Winner Criteria
 *****************************
 
-Custom Landing Page A/B test winner criteria get handled exactly the same as :ref:`Email A/B test winner criteria<Email tokens and A/B testing>` with the only differences being that the ``callback`` function gets passed ``Mautic\PageBundle\Entity\Page $page`` and ``Mautic\PageBundle\Entity\Page $parent`` instead.
+Custom Landing Page A/B test winner criteria get handled exactly the same as :ref:`Email A/B test winner criteria<components/emails:Email tokens and A/B testing>` with the only differences being that the ``callback`` function gets passed ``Mautic\PageBundle\Entity\Page $page`` and ``Mautic\PageBundle\Entity\Page $parent`` instead.
 ``$children`` is an ArrayCollection of Page entities as well.
 
 .. vale on

--- a/docs/components/points.rst
+++ b/docs/components/points.rst
@@ -12,17 +12,20 @@ In Mautic, custom Point Actions give a Contact `x` Points for doing a certain ac
 
 Mautic dispatches the Event ``\Mautic\PointBundle\PointEvents::POINT_ON_BUILD`` for Plugins to register their custom Point Action. Listeners receive a ``Mautic\PointBundle\Event\PointBuilderEvent`` object. Register the Event using the ``addAction`` method as described below.
 
-.. php:class:: Mautic\PointBundle\Event\PointBuilderEvent
+.. php:namespace:: Mautic\PointBundle\Event
+.. php:class:: PointBuilderEvent
 
-.. php:method:: public function addAction(string $key, array $action)
+  PointBuilderEvent class
 
-    :param string $key: Unique key for the Action.
-    :param array $action: :ref:`Action definition<Custom Point Action definition>`.
+  .. php:method:: public addAction(string $key, array $action)
 
-.. php:method:: public getActions()
+      :param string $key: Unique key for the Action.
+      :param array $action: :ref:`Action definition<Custom Point Action definition>`.
 
-    :return: Array of registered Actions.
-    :returntype: array
+  .. php:method:: public getActions()
+
+      :return: Array of registered Actions.
+      :returntype: array
 
 .. vale off
 

--- a/docs/components/points.rst
+++ b/docs/components/points.rst
@@ -20,7 +20,7 @@ Mautic dispatches the Event ``\Mautic\PointBundle\PointEvents::POINT_ON_BUILD`` 
   .. php:method:: public addAction(string $key, array $action)
 
       :param string $key: Unique key for the Action.
-      :param array $action: :ref:`Action definition<Custom Point Action definition>`.
+      :param array $action: :ref:`Action definition<components/points:Custom Point Action definition>`.
 
   .. php:method:: public getActions()
 
@@ -142,7 +142,7 @@ Mautic dispatches the Event ``\Mautic\PointBundle\PointEvents::TRIGGER_ON_BUILD`
 .. php:method:: public function addEvent(string $key, array $action)
 
     :param string $key: Unique key for the Action.
-    :param array $action: :ref:`Action definition<Custom Point Trigger definition>`.
+    :param array $action: :ref:`Action definition<components/points:Custom Point Trigger definition>`.
 
 .. php:method:: public getEvents()
 

--- a/docs/components/security.rst
+++ b/docs/components/security.rst
@@ -245,7 +245,7 @@ Mautic provides a few helper methods for common permission sets:
 
 **buildForm()**
 
-The ``buildForm()`` method appends the permission toggles to the Role's Form. See :ref:`Forms` for details on Form builders. Review the comments in the code sample.
+The ``buildForm()`` method appends the permission toggles to the Role's Form. See :ref:`components/forms:Forms` for details on Form builders. Review the comments in the code sample.
 
 There are complimentary helper methods for the common permission sets:
 

--- a/docs/components/tracking_script.rst
+++ b/docs/components/tracking_script.rst
@@ -61,7 +61,7 @@ You can embed ``mtc.js`` in third party websites to manage communication between
        }
    }
 
-To inject custom JavaScript into ``mtc.js``, use an :ref:`Event Listener<Event listeners>` for the ``CoreEvents::BUILD_MAUTIC_JS`` event.
+To inject custom JavaScript into ``mtc.js``, use an :ref:`Event Listener<plugins/event_listeners:Event listeners>` for the ``CoreEvents::BUILD_MAUTIC_JS`` event.
 This event receives a ``Mautic\CoreBundle\Event\BuildJsEvent`` object where ``$event->appendJs($js, $sectionName);`` can be used to inject the script's code.
 
 .. warning:: Note that the code that triggers the tracking call to Mautic has a priority of -255. Thus, any listener to this event should use a priority greater than -255.

--- a/docs/components/translator.rst
+++ b/docs/components/translator.rst
@@ -3,7 +3,7 @@ Translator
 
 Mautic leverages a decorated Symfony Translator service for translations.
 
-Visit :xref:`Translating Mautic` for information on how to translate Core. :ref:`Plugins must include their own translations<Translating plugins>`.
+Visit :xref:`Translating Mautic` for information on how to translate Core. :ref:`Plugins must include their own translations<plugins/translations:Translating plugins>`.
 
 Translation file and directory structure
 ****************************************
@@ -57,7 +57,7 @@ Translations are key/value pairs in the ``INI`` format. There is no hard and fas
 Using the Translator service
 ****************************
 
-Plugins have access to service by passing ``translator`` as :ref:`a service dependency<Service config items>`. Type-hint the argument in the service's construct with ``Symfony\Component\Translation\TranslatorInterface``.
+Plugins have access to service by passing ``translator`` as :ref:`a service dependency<plugins/config:Service config items>`. Type-hint the argument in the service's construct with ``Symfony\Component\Translation\TranslatorInterface``.
 
 In PHP templates, use ``$view['translator']`` to access the Translator service.
 

--- a/docs/components/ui.rst
+++ b/docs/components/ui.rst
@@ -29,7 +29,7 @@ Mautic dispatches the Event ``\Mautic\CoreBundle\CoreEvents::VIEW_INJECT_CUSTOM_
 
 .. php:method:: public function addButton(array $button, $location = null, $route = null)
 
-    :param array[] $button: :ref:`Details for button<Button Array Format>`.
+    :param array[] $button: :ref:`Details for button<components/ui:Button Array Format>`.
     :param string $location: Location of the Button to be placed.
     :param string $route: Route.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,3 +83,7 @@ linkcheck_ignore = [
    # github anchors cause failures, so do not check any github url with an anchor
    r'^https://github.com/.*#.*'
 ]
+
+# Ensure that autosectionlabel will produce unique names
+autosectionlabel_prefix_document = True
+# autosectionlabel_maxdepth = 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,10 +79,7 @@ html_static_path = ['_static']
 # A little context on the reason for ignoring is greatly appreciated!
 linkcheck_ignore = [
    # Incorrectly reported as 'Anchor "webhooks" not found' so ignoring this
-   'https://docs.mautic.org/en/setup/cron-jobs#webhooks'
-]
-
-linkcheck_anchors_ignore_for_url = [
-  # github anchors cause failures in make checklinks check
-  'https://github.com/mautic/mautic/.*'
+   'https://docs.mautic.org/en/setup/cron-jobs#webhooks',
+   # github anchors cause failures, so do not check any github url with an anchor
+   r'^https://github.com/.*#.*'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,3 +81,8 @@ linkcheck_ignore = [
    # Incorrectly reported as 'Anchor "webhooks" not found' so ignoring this
    'https://docs.mautic.org/en/setup/cron-jobs#webhooks'
 ]
+
+linkcheck_anchors_ignore_for_url = [
+  # github anchors cause failures in make checklinks check
+  'https://github.com/mautic/mautic/.*'
+]

--- a/docs/links/ab_testing.py
+++ b/docs/links/ab_testing.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "A/B testing" 
 link_text = "A/B testing" 
-link_url = "https://kb.mautic.org/knowledgebase/emails/how-does-mautic-do-ab-testing" 
+link_url = "https://kb.mautic.org/article/how-to-create-an-a-b-test-for-emails-in-mautic.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/ddev_install.py
+++ b/docs/links/ddev_install.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "ddev install" 
 link_text = "Install DDEV" 
-link_url = "https://ddev.readthedocs.io/en/stable/#installation" 
+link_url = "https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/symfony_tag_controller_service_arguments.py
+++ b/docs/links/symfony_tag_controller_service_arguments.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Symfony 4 controller service arguments tag" 
 link_text = "Symfony 4 controller service arguments tag" 
-link_url = "https://symfony.com/doc/current/controller/service.html#how-to-define-controllers-as-services" 
+link_url = "https://symfony.com/doc/4.x/controller/service.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/marketplace/listing.rst
+++ b/docs/marketplace/listing.rst
@@ -2,7 +2,7 @@ Listing a Plugin in the Marketplace
 ###################################
 
 .. note::
-    Do you already have a Plugin that you developed for previous versions of Mautic? Please see the :ref:`Updating existing Plugins for usage with the Marketplace` section below.
+    Do you already have a Plugin that you developed for previous versions of Mautic? Please see the :ref:`marketplace/listing:Updating existing Plugins for usage with the Marketplace` section below.
 
 Preparing your Plugin for the Marketplace
 *****************************************
@@ -67,4 +67,4 @@ If you required ``mautic/composer-plugin`` in your plugin's dependencies in the 
 
 Next to that, if you built your Plugin for Mautic 3 originally, please read the :xref:`UPGRADE-4.0.md guide` for the breaking changes in Mautic 4.
 
-When you're done, you can go back to the :ref:`Preparing your plugin for the Marketplace` section in this document and proceed from there.
+When you're done, you can go back to the :ref:`marketplace/listing:Preparing your plugin for the Marketplace` section in this document and proceed from there.

--- a/docs/plugins/config.rst
+++ b/docs/plugins/config.rst
@@ -42,7 +42,7 @@ Mautic recognizes the Plugin through the general config options.
 Routing config items
 ********************
 
-Routes define the URL paths that execute the specified controller action. Register routes with Mautic through the ``routes`` key in the Plugin's config. Define each route under one of Mautic's :ref:`supported firewalls<Routing firewalls>` with a uniquely identifying key and the :ref:`route's definition<Route definitions>`.
+Routes define the URL paths that execute the specified controller action. Register routes with Mautic through the ``routes`` key in the Plugin's config. Define each route under one of Mautic's :ref:`supported firewalls<plugins/config:Routing firewalls>` with a uniquely identifying key and the :ref:`route's definition<plugins/config:Route definitions>`.
 
 .. code-block:: php
 
@@ -193,7 +193,7 @@ Configure custom routes through writing a listener to the ``\Mautic\CoreBundle\C
 
 .. php:method:: getType()
 
-    :returns: The :ref:`route firewall<Routing firewalls>` for the given route collection.
+    :returns: The :ref:`route firewall<plugins/config:Routing firewalls>` for the given route collection.
     :returntype: string
 
 .. php:method:: getCollection()
@@ -317,7 +317,7 @@ Menu item definitions
 
 Define items in an ``items`` array along with ``priority`` or at the root of the menu's array.
 
-Key each item with its respective :ref:`language string key<Translating plugins>`.
+Key each item with its respective :ref:`language string key<plugins/translations:Translating plugins>`.
 
 .. list-table::
     :header-rows: 1
@@ -329,11 +329,11 @@ Key each item with its respective :ref:`language string key<Translating plugins>
     * - ``route``
       - conditional
       - string
-      - Name of the :ref:`Routing config items<Route definitions>` for this item. Leave undefined if the item is a placeholder for a sub-menu.
+      - Name of the :ref:`Routing config items<plugins/config:Route definitions>` for this item. Leave undefined if the item is a placeholder for a sub-menu.
     * - ``routeParameters``
       - no
       - array
-      - Key/value pairs of :ref:`path parameters<Route definitions>` for the given ``route``.
+      - Key/value pairs of :ref:`path parameters<plugins/config:Route definitions>` for the given ``route``.
     * - ``parent``
       - no
       - string
@@ -341,15 +341,15 @@ Key each item with its respective :ref:`language string key<Translating plugins>
     * - ``priority``
       - no
       - ``int``
-      - Determines the position of this item relative to it's sibling items. See :ref:`Menu item priority`.
+      - Determines the position of this item relative to it's sibling items. See :ref:`plugins/config:Menu item priority`.
     * - ``access``
       - no
       - string
-      - The :ref:`permission<Roles and permissions>` required to display this menu item. For example, ``category:categories:view`` or ``admin`` to restrict to only Administrators.
+      - The :ref:`permission<security-roles-and-permissions>` required to display this menu item. For example, ``category:categories:view`` or ``admin`` to restrict to only Administrators.
     * - ``checks``
       - no
       - array
-      - Define checks that must evaluate to ``TRUE`` to display the item. See :ref:`Menu item checks` for more details.
+      - Define checks that must evaluate to ``TRUE`` to display the item. See :ref:`plugins/config:Menu item checks` for more details.
     * - ``id``
       - no
       - string
@@ -513,7 +513,7 @@ For convenience, Mautic auto-tags services defined within specific keys.
       - Deprecated. Use service dependency injection instead.
     * - ``permissions``
       - ``mautic.permissions``
-      - Registers the service with Mautic's :ref:`permission service<Roles and permissions>`.
+      - Registers the service with Mautic's :ref:`permission service<security-roles-and-permissions>`.
     * - ``*`` or ``other``
       - n/a
       - You can use any other key you want to organize services in the config array. Note that this could risk incompatibility with a future version of Mautic if using something generic that Mautic starts to use as well.
@@ -553,11 +553,11 @@ Key each service with a unique name to all of Mautic, including other Plugins.
     * - ``tag``
       - no
       - string
-      - Define a :xref:`tag used by Symfony when compiling the container<Symfony 4 service tags>`. See :ref:`Mautic service tags` for Mautic specific tags.
+      - Define a :xref:`tag used by Symfony when compiling the container<Symfony 4 service tags>`. See :ref:`plugins/config:Mautic service tags` for Mautic specific tags.
     * - ``tags``
       - no
       - array
-      - An array of tags when there are more than one. See :ref:`Mautic service tags` for Mautic specific tags. This supersedes ``tag``.
+      - An array of tags when there are more than one. See :ref:`plugins/config:Mautic service tags` for Mautic specific tags. This supersedes ``tag``.
     * - ``tagArguments``
       - no
       - array
@@ -619,11 +619,11 @@ Mautic uses the follow tags to register services as described below.
       - none
       - Registers this service to handle webhooks from a :ref:`Text Message transport<Text Message transports>`.
     * - ``mautic.email_transport``
-      - Key/value pairs to configure fields required to authenticate with the transport's service. See :ref:`Email transports`.
-      - Registers the service as an :ref:`Email transport<Email transports>`.
+      - Key/value pairs to configure fields required to authenticate with the transport's service. See :ref:`components/emails:Email transports`.
+      - Registers the service as an :ref:`Email transport<components/emails:Email transports>`.
     * - ``mautic.email_stat_helper``
       - none
-      - Registers the service as a stat helper for Email charts. See :ref:`Email stat helpers`.
+      - Registers the service as a stat helper for Email charts. See :ref:`components/emails:Email stat helpers`.
 
 **Core tags**
 
@@ -635,7 +635,7 @@ Mautic uses the follow tags to register services as described below.
       - Description
     * - ``mautic.permissions``
       - none
-      - Registers the service as a permission object that must extend ``\Mautic\CoreBundle\Security\Permissions\AbstractPermissions``. See :ref:`Roles and permissions`. Services under the ``['services']['permissions']`` array do not require this.
+      - Registers the service as a permission object that must extend ``\Mautic\CoreBundle\Security\Permissions\AbstractPermissions``. See :ref:`security-roles-and-permissions`. Services under the ``['services']['permissions']`` array do not require this.
 
 **Integration tags**
 
@@ -647,19 +647,19 @@ Mautic uses the follow tags to register services as described below.
       - Description
     * - ``mautic.basic_integration``
       - none
-      - Registers the service as an :ref:`Integration<Integrations>`.
+      - Registers the service as an :ref:`Integration<components/integrations:Integrations>`.
     * - ``mautic.builder_integration``
       -  none
-      - Registers the service as a :ref:`Builder<Integration Builders>`.
+      - Registers the service as a :ref:`Builder<components/integrations:Integration Builders>`.
     * - ``mautic.authentication_integration``
       - none
-      - Registers the service to :ref:`authenticate with the Integration's service<Integration authentication>`.
+      - Registers the service to :ref:`authenticate with the Integration's service<components/integrations:Integration authentication>`.
     * - ``mautic.config_integration``
       - none
-      - Registers the service to :ref:`configure the Integration<Integration configuration>`.
+      - Registers the service to :ref:`configure the Integration<components/integrations:Integration configuration>`.
     * - ``mautic.sync_integration``
       - none
-      - Registers the service to :ref:`sync with Mautic objects with the Integration's service<Integration sync engine>`.
+      - Registers the service to :ref:`sync with Mautic objects with the Integration's service<components/integrations:Integration sync engine>`.
     * - ``mautic.sync.notification_handler``
       - none
       - Registers the service to handle :ref:`sync notifications<Sync notification handlers>`.
@@ -667,7 +667,7 @@ Mautic uses the follow tags to register services as described below.
 Category config items
 *********************
 
-Use ``categories`` to define Category types available to the Category manager. See :ref:`Categories`.
+Use ``categories`` to define Category types available to the Category manager. See :ref:`components/categories:Categories`.
 
 .. code-block:: php
 
@@ -684,7 +684,7 @@ Use ``categories`` to define Category types available to the Category manager. S
 Parameters config items
 ***********************
 
-Configure parameters that are consumable through Mautic's ``CoreParameterHelper``, passed into services with ``%mautic.key%``, or read from the environment via ``MAUTIC_KEY``. See :ref:`Configuration parameters` for more information.
+Configure parameters that are consumable through Mautic's ``CoreParameterHelper``, passed into services with ``%mautic.key%``, or read from the environment via ``MAUTIC_KEY``. See :ref:`components/config:Configuration parameters` for more information.
 
 .. code-block:: php
 
@@ -702,4 +702,4 @@ Configure parameters that are consumable through Mautic's ``CoreParameterHelper`
 
 .. note:: The default value must match the value's type for Mautic to typecast and transform appropriately. For example, if there isn't a specific default value to declare, define an empty array, ``[]``, for an array type; zero, ``0``, for an integer type; ``TRUE`` or ``FALSE`` for boolean types; and so forth. Services leveraging parameters should accept and handle ``NULL`` for integer and string types, excluding ``0``.
 
-.. note:: Parameters aren't exposed to the UI by default. See :ref:`Configuration` for more information.
+.. note:: Parameters aren't exposed to the UI by default. See :ref:`components/config:Configuration` for more information.

--- a/docs/plugins/config.rst
+++ b/docs/plugins/config.rst
@@ -614,10 +614,10 @@ Mautic uses the follow tags to register services as described below.
       - Description
     * - ``mautic.sms_transport``
       - ``['integrationAlias' => 'Name to display in the UI for this transport.']``
-      - Register this service as a :ref:`Text Message transport<Text Message transports>`.
+      - Register this service as a Text Message transport.
     * - ``mautic.sms_callback_handler``
       - none
-      - Registers this service to handle webhooks from a :ref:`Text Message transport<Text Message transports>`.
+      - Registers this service to handle webhooks from a Text Message transport.
     * - ``mautic.email_transport``
       - Key/value pairs to configure fields required to authenticate with the transport's service. See :ref:`components/emails:Email transports`.
       - Registers the service as an :ref:`Email transport<components/emails:Email transports>`.
@@ -662,7 +662,7 @@ Mautic uses the follow tags to register services as described below.
       - Registers the service to :ref:`sync with Mautic objects with the Integration's service<components/integrations:Integration sync engine>`.
     * - ``mautic.sync.notification_handler``
       - none
-      - Registers the service to handle :ref:`sync notifications<Sync notification handlers>`.
+      - Registers the service to handle sync notifications.
 
 Category config items
 *********************

--- a/docs/plugins/data.rst
+++ b/docs/plugins/data.rst
@@ -235,7 +235,7 @@ Plugin schema migrations
 
 Mautic Core uses :xref:`Doctrine migrations<Doctrine migrations bundle>` to manage schema changes. Plugins don't have access to this as migration files are in Core's ``migrations`` directory.
 
-Mautic provides a way for Plugins to manage their schema changes through the Integration bundle's ``\Mautic\IntegrationsBundle\Migration\Engine``. Mautic automatically handles migrations if the :ref:`Plugin's bundle class<File and directory structure>` extends ``Mautic\IntegrationsBundle\Bundle\AbstractPluginBundle``.
+Mautic provides a way for Plugins to manage their schema changes through the Integration bundle's ``\Mautic\IntegrationsBundle\Migration\Engine``. Mautic automatically handles migrations if the :ref:`Plugin's bundle class<plugins/structure:File and directory structure>` extends ``Mautic\IntegrationsBundle\Bundle\AbstractPluginBundle``.
 
 .. code-block:: php
 

--- a/docs/plugins/dependencies.rst
+++ b/docs/plugins/dependencies.rst
@@ -7,4 +7,4 @@ The first is to include dependencies with your distributable Plugin package. How
 
 The recommended approach is to use Composer and make the Plugin available through the new Marketplace.
 
-Preparing your Plugin for the Marketplace by leveraging :xref:`Mautic's Composer plugin`. For detailed instructions, refer to the :doc:`/marketplace/listing`.
+:ref: `marketplace/listing:Preparing your Plugin for the Marketplace` by leveraging :xref:`Mautic's Composer plugin`. For detailed instructions, refer to the :doc:`/marketplace/listing`.

--- a/docs/plugins/installation.rst
+++ b/docs/plugins/installation.rst
@@ -3,7 +3,7 @@ Installing, upgrading, and uninstalling
 
 Mautic informs your Plugin when it gets installed or updated through the ``ON_PLUGIN_INSTALL`` and ``ON_PLUGIN_UPDATE`` events. This can be useful in scenarios where you need to set up certain data structures or do other configuration work. Note that there is currently no hook for when your Plugin gets uninstalled. If that's of interest, please feel free to :xref:`contribute that functionality<Contributing to Mautic>`.
 
-.. note:: If your Plugin manages its own schema, Mautic recommends using :ref:`database migrations` instead of the generic events mentioned earlier.
+.. note:: If your Plugin manages its own schema, Mautic recommends using :ref:`plugins/installation:database migrations` instead of the generic events mentioned earlier.
 
 Install and update events
 =========================

--- a/docs/plugins/mautic_vs_symfony.rst
+++ b/docs/plugins/mautic_vs_symfony.rst
@@ -16,7 +16,7 @@ Mautic uses directory paths that aren't typical in Symfony to make it distributa
     * - ``app/config/``
       - Symfony configuration files
     * - ``app/middlewares/``
-      - See :ref:`Middlewares`
+      - See :ref:`plugins/mautic_vs_symfony:Middlewares`
     * - ``app/migrations/``
       - Doctrine migrations that updates Core's database schema
     * - ``bin/console/``
@@ -28,9 +28,9 @@ Mautic uses directory paths that aren't typical in Symfony to make it distributa
     * - ``themes/``
       - Mautic Themes
     * - ``themes/system``
-      - :ref:`Contains custom overrides for Mautic Core templates<Overriding core view templates>`
+      - :ref:`Contains custom overrides for Mautic Core templates<themes/system:Overriding core view templates>`
     * - ``translations/``
-      - Mautic translation files leveraged by Mautic's custom :ref:`Translator`
+      - Mautic translation files leveraged by Mautic's custom :ref:`components/translator:Translator`
     * - ``var/``
       - Contains temporary files such as logs and Symfony's cache
     * - ``vendor/``
@@ -76,7 +76,7 @@ Services are public by default to have backwards compatibility with Mautic 3 and
 
 Support for entity annotations
 ******************************
-By default, Mautic uses Doctrine's PHP driver instead of annotations which requires a ``public static function loadMetadata(ORM\ClassMetadata $metadata)`` method. However, Plugins can use annotations if desired but should use only annotations or only PHP ``loadMetadata``. A Plugin can't use a mix of both. See :ref:`Entities and schema` for more information.
+By default, Mautic uses Doctrine's PHP driver instead of annotations which requires a ``public static function loadMetadata(ORM\ClassMetadata $metadata)`` method. However, Plugins can use annotations if desired but should use only annotations or only PHP ``loadMetadata``. A Plugin can't use a mix of both. See :ref:`plugins/data:Entities and schema` for more information.
 
 Firewalls and User access management
 ************************************

--- a/docs/plugins/mautic_vs_symfony.rst
+++ b/docs/plugins/mautic_vs_symfony.rst
@@ -36,7 +36,7 @@ Mautic uses directory paths that aren't typical in Symfony to make it distributa
     * - ``vendor/``
       - Contains Composer installed dependencies
 
-Mautic mostly uses Symfony's 2.x/3.x bundle structure for Core bundles in ``app\bundles\`` and custom Plugins in ``plugins\``. Read more about these :ref:`here<File and directory structure>`.
+Mautic mostly uses Symfony's 2.x/3.x bundle structure for Core bundles in ``app\bundles\`` and custom Plugins in ``plugins\``. Read more about these :ref:`here<plugins/structure:File and directory structure>`.
 
 PHP everything
 **************

--- a/docs/plugins/translations.rst
+++ b/docs/plugins/translations.rst
@@ -1,7 +1,7 @@
 Translating Plugins
 ###################
 
-Plugins include their own translations in their ``Translations`` directories organized by locale. Currently, only :xref:`Core translations are supported through Transifex<Translating Mautic>`. See :ref:`Translator` for information on writing translations and using the Translator service in your Plugin.
+Plugins include their own translations in their ``Translations`` directories organized by locale. Currently, only :xref:`Core translations are supported through Transifex<Translating Mautic>`. See :ref:`components/translator:Translator` for information on writing translations and using the Translator service in your Plugin.
 
 .. note:: All Plugins must include a US English, en_US, translation.
 

--- a/docs/rest_api/contacts.rst
+++ b/docs/rest_api/contacts.rst
@@ -396,7 +396,7 @@ You can find a list of available expressions on :xref:`Doctrine ORM's website<Do
 
 **Properties**
 
-Same as :ref:`Get Contact`.
+Same as :ref:`rest_api/contacts:Get Contact`.
 
 .. vale off
 
@@ -454,7 +454,7 @@ Create a new Contact.
 
 **Properties**
 
-Same as :ref:`Get Contact`.
+Same as :ref:`rest_api/contacts:Get Contact`.
 
 .. vale off
 
@@ -516,7 +516,7 @@ Create a batch of new Contacts.
 
 **Properties**
 
-Array of Contacts. Record is the same as :ref:`Get Contact`.
+Array of Contacts. Record is the same as :ref:`rest_api/contacts:Get Contact`.
 
 .. vale off
 
@@ -584,7 +584,7 @@ If ``PATCH``, the expected response code is ``200``.
 
 **Properties**
 
-Same as :ref:`Get Contact`.
+Same as :ref:`rest_api/contacts:Get Contact`.
 
 .. note:: In order to remove a tag from the Contact, add minus ``-`` before it. For example: ``tags: ['one', '-two']`` - sending this in request body will add tag ``one`` and remove tag ``two`` from Contact.
 
@@ -665,7 +665,7 @@ If ``PATCH``, the expected response code is ``200``.
 
 **Properties**
 
-Contacts array. Record same as :ref:`Get Contact`.
+Contacts array. Record same as :ref:`rest_api/contacts:Get Contact`.
 
 .. note:: In order to remove a tag from the Contact, add minus ``-`` before it. For example: ``tags: ['one', '-two']`` - sending this in request body will add tag ``one`` and remove tag ``two`` from Contact.
 
@@ -698,7 +698,7 @@ Delete a Contact.
 
 **Properties**
 
-Same as :ref:`Get Contact`.
+Same as :ref:`rest_api/contacts:Get Contact`.
 
 .. vale off
 
@@ -733,7 +733,7 @@ If you aren't using PHP, here is a URL example:
 
 **Properties**
 
-Contacts array. Record same as :ref:`Get Contact`.
+Contacts array. Record same as :ref:`rest_api/contacts:Get Contact`.
 
 .. vale off
 
@@ -830,7 +830,7 @@ To remove ``Do Not Contact`` entry from a Contact:
 
 **Response**
 
-Same as :ref:`Get Contact`.
+Same as :ref:`rest_api/contacts:Get Contact`.
 
 .. vale off
 
@@ -909,7 +909,7 @@ Mautic requires the parameter array. Each ``UTM`` tag entry is optional.
 
 **Response**
 
-Same as :ref:`Get Contact` with the added UTM Tags.
+Same as :ref:`rest_api/contacts:Get Contact` with the added UTM Tags.
 
 .. vale off
 
@@ -941,7 +941,7 @@ None required.
 
 **Response**
 
-Same as :ref:`Get Contact` without the removed UTM Tags.
+Same as :ref:`rest_api/contacts:Get Contact` without the removed UTM Tags.
 
 .. vale off
 

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -51,13 +51,13 @@ authorUrl
 features
     An array of strings that tells Mautic which features the Theme supports. Currently recognized values are:
 
-    ``email`` The Theme is compatible with the Email Builder. See :ref:`html/email.html.twig`.
+    ``email`` The Theme is compatible with the Email Builder. See :ref:`themes/getting_started:html/email.html.twig`.
 
-    ``form`` The Theme is compatible with the customizing Forms. See :ref:`html/form.html.twig`.
+    ``form`` The Theme is compatible with the customizing Forms. See :ref:`themes/getting_started:html/form.html.twig`.
 
-    ``page`` The Theme is compatible with the Page Builder. See :ref:`html/page.html.twig`.
+    ``page`` The Theme is compatible with the Page Builder. See :ref:`themes/getting_started:html/page.html.twig`.
 
-    A corresponding ``html/[feature].html.twig`` file is required for each feature supported. For example, if the Theme supports ``email``, then there should be a ``html/email.html.twig`` file. See :ref:`Twig files` more information on each feature.
+    A corresponding ``html/[feature].html.twig`` file is required for each feature supported. For example, if the Theme supports ``email``, then there should be a ``html/email.html.twig`` file. See :ref:`themes/getting_started:Twig files` more information on each feature.
 builder
     This contains an array of strings declaring which Builder the Theme supports. This currently only applies to Themes that support ``page`` or ``email``. By default, Themes without this line are only recognized by Mautic's legacy builder. New Themes built should declare the specific Builders it supports.
 
@@ -164,7 +164,7 @@ Mautic uses this file when accessing the form at /form/ID, embedding a Form in a
 
 This should output the variables ``message``, ``header``, and ``content``.
 
-See :ref:`Customizing forms` on how to customize Form fields.
+See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
 
 .. code-block:: twig
 

--- a/docs/webhooks/events/company_post_delete.rst
+++ b/docs/webhooks/events/company_post_delete.rst
@@ -26,7 +26,7 @@ Event properties
       - ID of the deleted Company
     * - ``company``
       - object
-      - :ref:`Company object<Company properties>`. Note that ``id`` is null in this context. Use the ``id`` in the event instead.
+      - :ref:`Company object<webhooks/events/company_post_save:Company properties>`. Note that ``id`` is null in this context. Use the ``id`` in the event instead.
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format.

--- a/docs/webhooks/events/company_post_save.rst
+++ b/docs/webhooks/events/company_post_save.rst
@@ -23,7 +23,7 @@ Event properties
       - Description
     * - ``company``
       - object
-      - :ref:`Company object<Company properties>`.
+      - :ref:`Company object<webhooks/events/company_post_save:Company properties>`.
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format.
@@ -97,4 +97,4 @@ Company properties
       - The Company's behavior score - similar to Contact Points.
     * - ``fields``
       - object|array
-      -  Mautic groups fields by Field Groups keyed as one of ``core``, ``social``, ``personal``, and ``professional``. Each ``fieldGroup`` has an object of Fields keyed by the Field's API name. See :ref:`Custom Field object<Custom Field properties>` for each Field's properties. Note that this could be an object if there are Fields available. Otherwise, Mautic sets an empty array. For example, ``$companyCity = $company['fields']['core']['city']['value'];``.
+      -  Mautic groups fields by Field Groups keyed as one of ``core``, ``social``, ``personal``, and ``professional``. Each ``fieldGroup`` has an object of Fields keyed by the Field's API name. See :ref:`Custom Field object<webhooks/events/lead_post_save_new:Custom Field properties>` for each Field's properties. Note that this could be an object if there are Fields available. Otherwise, Mautic sets an empty array. For example, ``$companyCity = $company['fields']['core']['city']['value'];``.

--- a/docs/webhooks/events/email_on_send.rst
+++ b/docs/webhooks/events/email_on_send.rst
@@ -23,10 +23,10 @@ Event properties
       - Description
     * - ``email``
       - object
-      - :ref:`Email object<Email properties>`
+      - :ref:`Email object<webhooks/events/email_on_send:Email properties>`
     * - ``contact``
       - object
-      - :ref:`Contact object<Contact properties>`
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`
     * - ``tokens``
       - object
       - Key/value pairs of personalized tokens and values for the Contact.
@@ -96,7 +96,7 @@ Email properties
       - Locale for the Email content.
     * - ``category``
       - object
-      - :ref:`Category object<Category properties>`
+      - :ref:`Category object<webhooks/events/email_on_send:Category properties>`
     * - ``fromAddress``
       - string|null
       - A custom from address if configured.
@@ -144,7 +144,7 @@ Email properties
       - Date/time for unpublishing the Email in ISO 8601 format. ``null`` to consider the Email published if now is after ``publishUp``, if applicable.
     * - ``assetAttachments``
       - array
-      - Array of :ref:`Asset objects<Asset properties>`.
+      - Array of :ref:`Asset objects<webhooks/events/email_on_send:Asset properties>`.
     * - ``variantStartDate``
       - string|null
       - Date/time the Email started to track A/B test statistics. ``null`` if the Email isn't part of an A/B test.
@@ -156,22 +156,22 @@ Email properties
       - The number of times read since the last edit to an A/B test Email.
     * - ``variantParent``
       - object|null
-      - :ref:`Email object<Email properties>`. The A test for an Email configured as an A/B test.
+      - :ref:`Email object<webhooks/events/email_on_send:Email properties>`. The A test for an Email configured as an A/B test.
     * - ``variantChildren``
       - array
-      - Array of  :ref:`Email objects<Email properties>`. The B, C, D, and so forth tests for an Email configured as an A/B test.
+      - Array of  :ref:`Email objects<webhooks/events/email_on_send:Email properties>`. The B, C, D, and so forth tests for an Email configured as an A/B test.
     * - ``translationParent``
       - object|null
-      - :ref:`Email object<Email properties>`. The main translation of an Email configured to be a translation of another.
+      - :ref:`Email object<webhooks/events/email_on_send:Email properties>`. The main translation of an Email configured to be a translation of another.
     * - ``translationChildren``
       - array
-      - Array of :ref:`Email objects<Email properties>`. The translations of an Email configured to be a translation of another.
+      - Array of :ref:`Email objects<webhooks/events/email_on_send:Email properties>`. The translations of an Email configured to be a translation of another.
     * - ``unsubscribeForm``
       - object|null
-      - :ref:`Unsubscribe Form object<Unsubscribe Form properties>`.
+      - :ref:`Unsubscribe Form object<webhooks/events/email_on_send:Unsubscribe Form properties>`.
     * - ``lists``
       - array
-      - :ref:`Segment object<Segment properties>`.
+      - :ref:`Segment object<webhooks/events/email_on_send:Segment properties>`.
     * - ``headers``
       - array
       - Key/value pairs of header templates configured for the Email.
@@ -233,7 +233,7 @@ Asset properties
       - Description of the Asset.
     * - ``category``
       - object
-      - :ref:`Category object<Category properties>`
+      - :ref:`Category object<webhooks/events/email_on_send:Category properties>`
     * - ``revision``
       - int
       - The number of edits of the Asset.
@@ -291,7 +291,7 @@ Segment properties
       - Description of the Segment.
     * - ``category``
       - object
-      - :ref:`Category object<Category properties>`
+      - :ref:`Category object<webhooks/events/email_on_send:Category properties>`
     * - ``createdByUser``
       - string
       - The name of the User that created the Segment.
@@ -306,7 +306,7 @@ Segment properties
       - ``TRUE`` if configured to display in the Preference Center for Contact Segments. ``FALSE`` otherwise.
     * - ``filters``
       - array
-      - Array of :ref:`Segment filter objects<Segment filter properties>`.
+      - Array of :ref:`Segment filter objects<webhooks/events/email_on_send:Segment filter properties>`.
 
 Segment filter properties
 *************************
@@ -366,7 +366,7 @@ Unsubscribe Form properties
       - Description of the Form.
     * - ``category``
       - object
-      - :ref:`Category object<Category properties>`
+      - :ref:`Category object<webhooks/events/email_on_send:Category properties>`
     * - ``createdByUser``
       - string
       - Name of the User that created the Form.
@@ -384,7 +384,7 @@ Unsubscribe Form properties
       - Cached rendered HTML for the Form.
     * - ``template``
       - string|null
-      - Custom Mautic Theme used to style the Preview page or customize Form fields. See :ref:`Customizing forms`.
+      - Custom Mautic Theme used to style the Preview page or customize Form fields. See :ref:`themes/forms:Customizing forms`.
     * - ``formType``
       - string
       - Applicable values are ``standalone`` or ``campaign``.
@@ -408,10 +408,10 @@ Unsubscribe Form properties
       - HTML attributes added to the <form> tag.
     * - ``fields``
       - array
-      - Array of :ref:`Unsubscribe Form field objects<Unsubscribe Form field properties>`
+      - Array of :ref:`Unsubscribe Form field objects<webhooks/events/email_on_send:Unsubscribe Form field properties>`
     * - ``actions``
       - array
-      - Array of :ref:`Unsubscribe Form action objects<Unsubscribe Form action properties>`
+      - Array of :ref:`Unsubscribe Form action objects<webhooks/events/email_on_send:Unsubscribe Form action properties>`
 
 .. vale off
 

--- a/docs/webhooks/events/form_on_submit.rst
+++ b/docs/webhooks/events/form_on_submit.rst
@@ -48,7 +48,7 @@ Submission properties
       - :ref:`Form basic object<Form basic properties>`.
     * - ``lead``
       - object
-      - :ref:`Contact object<Contact properties>`.
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``trackingId``
       - string
       - Generated ID for the tracking session.
@@ -85,7 +85,7 @@ Form basic properties
       - API name for the Form
     * - ``category``
       - object
-      - :ref:`Category object<Category properties>`
+      - :ref:`Category object<webhooks/events/email_on_send:Category properties>`
 
 IP address basic properties
 ***************************

--- a/docs/webhooks/events/form_on_submit.rst
+++ b/docs/webhooks/events/form_on_submit.rst
@@ -23,7 +23,7 @@ Event properties
       - Description
     * - ``submission``
       - object
-      - :ref:`Submission object<Submission properties>`
+      - :ref:`Submission object<webhooks/events/form_on_submit:Submission properties>`
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format.
@@ -42,10 +42,10 @@ Submission properties
       - ID of the Submission.
     * - ``ipAddress``
       - object
-      - :ref:`IP address basic object<IP address basic properties>` for the Contact when they submitted the Form.
+      - :ref:`IP address basic object<webhooks/events/form_on_submit:IP address basic properties>` for the Contact when they submitted the Form.
     * - ``form``
       - object
-      - :ref:`Form basic object<Form basic properties>`.
+      - :ref:`Form basic object<webhooks/events/form_on_submit:Form basic properties>`.
     * - ``lead``
       - object
       - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
@@ -63,7 +63,7 @@ Submission properties
       - Key/value pairs with Form field API names as the keys and submitted values.
     * - ``page``
       - object|null
-      - :ref:`Landing Page basic object<Landing Page basic properties>` if the Contact submitted the Form when embedded on a Landing Page. Otherwise, ``null``.
+      - :ref:`Landing Page basic object<webhooks/events/page_on_hit:Landing Page basic properties>` if the Contact submitted the Form when embedded on a Landing Page. Otherwise, ``null``.
 
 Form basic properties
 *********************

--- a/docs/webhooks/events/lead_channel_subscription_changed.rst
+++ b/docs/webhooks/events/lead_channel_subscription_changed.rst
@@ -23,7 +23,7 @@ Event properties
       - Description
     * - ``contact``
       - object
-      - :ref:`Contact object<Contact properties>`.
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``channel``
       - string
       - The Channel unsubscribed from. Examples are ``email`` and ``sms``.

--- a/docs/webhooks/events/lead_company_change.rst
+++ b/docs/webhooks/events/lead_company_change.rst
@@ -29,7 +29,7 @@ Event properties
       - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``company``
       - object
-      - :ref:`Company object<Company properties>`.
+      - :ref:`Company object<webhooks/events/company_post_save:Company properties>`.
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format.

--- a/docs/webhooks/events/lead_company_change.rst
+++ b/docs/webhooks/events/lead_company_change.rst
@@ -26,7 +26,7 @@ Event properties
       - ``TRUE`` if Contact added to the Company. ``FALSE`` if removed.
     * - ``contact``
       - object
-      - :ref:`Contact object<Contact properties>`.
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``company``
       - object
       - :ref:`Company object<Company properties>`.

--- a/docs/webhooks/events/lead_points_change.rst
+++ b/docs/webhooks/events/lead_points_change.rst
@@ -23,7 +23,7 @@ Event properties
       - Description
     * - ``contact``
       - object
-      - :ref:`Contact object<Contact properties>`.
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``points``
       - object
       - Contains the original Points and the new Points for the Contact.

--- a/docs/webhooks/events/lead_post_delete.rst
+++ b/docs/webhooks/events/lead_post_delete.rst
@@ -26,7 +26,7 @@ Event properties
       - ID of the deleted Contact
     * - ``company``
       - object
-      - :ref:`Contact object<Contact properties>`. Note that ``id`` is null in this context. Use the ``id`` in the event instead.
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`. Note that ``id`` is null in this context. Use the ``id`` in the event instead.
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format.

--- a/docs/webhooks/events/lead_post_save_new.rst
+++ b/docs/webhooks/events/lead_post_save_new.rst
@@ -25,7 +25,7 @@ Event properties
       - Description
     * - ``contact``
       - object
-      - :ref:`Contact object<Contact properties>`
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format.

--- a/docs/webhooks/events/lead_post_save_new.rst
+++ b/docs/webhooks/events/lead_post_save_new.rst
@@ -77,22 +77,22 @@ Contact properties
       - Preferred image to display for the Contact. Defaults to ``gravatar``.
     * - ``fields``
       - object|array
-      -  Mautic groups fields by Field Groups keyed as one of ``core``, ``social``, ``personal``, and ``professional``. Each ``fieldGroup`` has an object of Fields keyed by the Field's API name. See :ref:`Custom Field object<Custom Field properties>` for each Field's properties. Note that this could be an object if there are Fields available. Otherwise, Mautic sets an empty array. For example, ``$firstname = $contact['fields']['core']['firstname']['value'];``.
+      -  Mautic groups fields by Field Groups keyed as one of ``core``, ``social``, ``personal``, and ``professional``. Each ``fieldGroup`` has an object of Fields keyed by the Field's API name. See :ref:`Custom Field object<webhooks/events/lead_post_save_new:Custom Field properties>` for each Field's properties. Note that this could be an object if there are Fields available. Otherwise, Mautic sets an empty array. For example, ``$firstname = $contact['fields']['core']['firstname']['value'];``.
     * - ``lastActive``
       - string|null
       - Date/time the Contact was last active in ISO 8601 format or null if it hasn't been active.
     * - ``owner``
       - object|null
-      - :ref:`User object<Owner properties>` or null if no Owner assigned.
+      - :ref:`User object<webhooks/events/lead_post_save_new:Owner properties>` or null if no Owner assigned.
     * - ``ipAddresses``
       - object
-      - :ref:`IP Address object<IP address properties>`.
+      - :ref:`IP Address object<webhooks/events/lead_post_save_new:IP address properties>`.
     * - ``tags``
       - object
-      - :ref:`Tag object<Tag properties>`.
+      - :ref:`Tag object<webhooks/events/lead_post_save_new:Tag properties>`.
     * - ``doNotContact``
       - array of objects
-      - Array of :ref:`Channel subscription objects<Channel subscription properties>`.
+      - Array of :ref:`Channel subscription objects<webhooks/events/lead_post_save_new:Channel subscription properties>`.
     * - ``frequencyRules``
       - array
       - Currently not populated for Webhooks.

--- a/docs/webhooks/events/page_on_hit.rst
+++ b/docs/webhooks/events/page_on_hit.rst
@@ -23,7 +23,7 @@ Event properties
       - Description
     * - ``hit``
       - object
-      - :ref:`Page visit object<Page visit properties>`
+      - :ref:`Page visit object<webhooks/events/page_on_hit:Page visit properties>`
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format.
@@ -48,13 +48,13 @@ Page visit properties
       - Always ``null`` for Webhook events.
     * - ``page``
       - object
-      - :ref:`Landing Page basic object<Landing Page basic properties>`.
+      - :ref:`Landing Page basic object<webhooks/events/page_on_hit:Landing Page basic properties>`.
     * - ``lead``
       - object
       - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``ipAddress``
       - object
-      - :ref:`IP address basic object<IP address basic properties>` for the Contact when they visited the Page.
+      - :ref:`IP address basic object<webhooks/events/form_on_submit:IP address basic properties>` for the Contact when they visited the Page.
     * - ``country``
       - string
       - Country gleaned from tracked IP address.

--- a/docs/webhooks/events/page_on_hit.rst
+++ b/docs/webhooks/events/page_on_hit.rst
@@ -51,7 +51,7 @@ Page visit properties
       - :ref:`Landing Page basic object<Landing Page basic properties>`.
     * - ``lead``
       - object
-      - :ref:`Contact object<Contact properties>`.
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``ipAddress``
       - object
       - :ref:`IP address basic object<IP address basic properties>` for the Contact when they visited the Page.
@@ -137,4 +137,4 @@ Landing Page basic properties
       - API name for the Landing Page.
     * - ``category``
       - object
-      - :ref:`Category object<Category properties>`.
+      - :ref:`Category object<webhooks/events/email_on_send:Category properties>`.

--- a/docs/webhooks/events/sms_on_send.rst
+++ b/docs/webhooks/events/sms_on_send.rst
@@ -26,7 +26,7 @@ Event properties
       - ID of the SMS sent.
     * - ``contact``
       - object
-      - :ref:`Contact object<Contact properties>`.
+      - :ref:`Contact object<webhooks/events/lead_post_save_new:Contact properties>`.
     * - ``content``
       - string
       - Content of the SMS sent to the Contact.

--- a/docs/webhooks/getting_started.rst
+++ b/docs/webhooks/getting_started.rst
@@ -13,7 +13,7 @@ The structure of Webhook payloads are as follows. ``WebhookEventType`` would be 
         ]
     }
 
-Mautic aggregates event types and payloads when using the :ref:`Background workflow`.
+Mautic aggregates event types and payloads when using the :ref:`webhooks/getting_started:Background workflow`.
 
 .. code-block:: javascript
 
@@ -30,7 +30,7 @@ Mautic aggregates event types and payloads when using the :ref:`Background workf
         ]
     }
 
-Review :ref:`Webhook events and payloads` for a list of event types and the structure of their payloads.
+Review :ref:`webhooks/events/index:Webhook events and payloads` for a list of event types and the structure of their payloads.
 
 Webhook workflows
 *****************
@@ -90,13 +90,13 @@ Creating a Webhook
 
 .. vale on
 
-Each app or script should have its own Webhook configured to minimize the number of places exposing the :ref:`secret key<Securing a Webhook>`.
+Each app or script should have its own Webhook configured to minimize the number of places exposing the :ref:`secret key<webhooks/getting_started:Securing a Webhook>`.
 
 1. Click ``Webhooks`` from the Admin Menu, displayed by clicking the cog icon in the top right corner.
 2. Click New.
 3. Fill in a Name, Webhook POST URL, and select which Events should trigger this Webhook. You can also customize the signature if you want or leave set as the default that's uniquely and randomly generated.
 4. Click Apply.
-5. :ref:`Test the Webhook<Testing a Webhook>`.
+5. :ref:`Test the Webhook<webhooks/getting_started:Testing a Webhook>`.
 
 .. vale off
 
@@ -107,7 +107,7 @@ Testing a Webhook
 
 If you don't already have somewhere to send the Webhook, you can use a service like :xref:`RequestBin`.
 
-If following the instructions to :ref:`create a Webhook<Creating a Webhook>`, you should be on the form to edit your Webhook. If otherwise, go to Webhooks in the Admin Menu, click the Webhook, then click Edit.
+If following the instructions to :ref:`create a Webhook<webhooks/getting_started:Creating a Webhook>`, you should be on the form to edit your Webhook. If otherwise, go to Webhooks in the Admin Menu, click the Webhook, then click Edit.
 
 You should see a `Send Test Payload` button when editing a Webhook. Click it and Mautic sends an example request to the POST URL configured.
 


### PR DESCRIPTION
### Description

fixes #165 (partially atm)

So far:

- Fix duplicate object description by adding namespaces to the 2 classes in question. Ideally we should use namespaces for all classes and reference them using the full namespace.
- Fix broken links
- Fix "Title level inconsistent"
- Fix undefined/wrong labels
- - sync notification handlers is truly missing
- - text message transports is truly missing
- - we need to figure out where these were supposed to link to