### PR TITLE
fix linter - missing doctrine-project links

### DIFF
--- a/docs/links/doctrine_docs_orm.py
+++ b/docs/links/doctrine_docs_orm.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Doctrine ORM"
 link_text = "Doctrine ORM"
-link_url = "https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/index.html" 
+link_url = "https://www.doctrine-project.org/projects/doctrine-orm/en/2.14/index.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/doctrine_docs_orm_annotations.py
+++ b/docs/links/doctrine_docs_orm_annotations.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Doctrine ORM annotations"
 link_text = "Doctrine ORM annotations"
-link_url = "https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/annotations-reference.html" 
+link_url = "https://www.doctrine-project.org/projects/doctrine-orm/en/2.14/reference/annotations-reference.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/doctrine_docs_orm_php_mapping.py
+++ b/docs/links/doctrine_docs_orm_php_mapping.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Doctrine ORM PHP mapping"
 link_text = "Doctrine ORM PHP mapping"
-link_url = "https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/php-mapping.html#classmetadatabuilder"
+link_url = "https://www.doctrine-project.org/projects/doctrine-orm/en/2.14/reference/php-mapping.html#classmetadatabuilder"
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
Previous links https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/index.html return 404 = probably dead.

Based on current Mautic 5.x docker image - composer.lock - changing documentation link to `v2.14`.