### PR TITLE
Set Vale back to suggestion level for alerts

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,5 @@
 StylesPath = .github/styles
 Vocab = Mautic
-MinAlertLevel = warning
+MinAlertLevel = suggestion
 [*.{md,rst}]
 BasedOnStyles = Vale, Google, Mautic


### PR DESCRIPTION
Setting Vale to warning means that writers are missing some important grammar fixes which should be implemented, and which reviewers would only be notified about if they took the trouble to check it out in an IDE with Vale enabled.

We should be setting the alert level at suggestion, and where appropriate using vale off if the suggestion isn't relevant, rather than missing a whole bunch of grammar improvements, IMO.