### PR TITLE
Small fix for missing inline code syntax

### DIFF
--- a/docs/testing/e2e_test_suite.rst
+++ b/docs/testing/e2e_test_suite.rst
@@ -41,7 +41,7 @@ In acceptance tests, your tests interact with the app through a web server, usin
 
 Whenever you need to run the tests, make sure to update ``.env.local`` to enable test mode.
 
-1. Edit .env.local:
+1. Edit ``.env.local``:
 
 Set the environment to test mode.
 


### PR DESCRIPTION
Just noticed this while reading the docs, we missed an inline code snippet here.