### PR TITLE
[UI] Retrieving system information in Twig

### DIFF
--- a/docs/design/retriving_system_information.rst
+++ b/docs/design/retriving_system_information.rst
@@ -32,6 +32,12 @@ To directly display a configuration value in your template, use the following sy
 
    {{ configGetParameter('parameter_name') }}
 
+You can also define the default value as a second parameter:
+
+.. code-block:: twig
+
+   {{ configGetParameter('parameter_name', 'default value') }}
+
 For example, to display the API OAuth2 access token lifetime:
 
 .. code-block:: twig

--- a/docs/design/retriving_system_information.rst
+++ b/docs/design/retriving_system_information.rst
@@ -64,7 +64,6 @@ Additional information
 ----------------------
 
 - Be cautious when displaying sensitive configuration data in templates.
-- Avoid excessive use of ``configGetParameter`` in loops or frequently rendered templates to prevent performance issues.
 - Always consider providing default values when using configuration parameters to handle cases where the setting might not be defined.
 
 Using the ``configGetParameter`` function in Twig, you can create new interactive experiences in Mautic.

--- a/docs/design/retriving_system_information.rst
+++ b/docs/design/retriving_system_information.rst
@@ -47,7 +47,7 @@ For example, to display the API OAuth2 access token lifetime:
 Finding available parameters
 ----------------------------
 
-All available configuration parameters are located in the ``/config/local.php`` file once you save the global configuration form for the first time. This file contains the complete list of settings that are accessible using ``configGetParameter``.
+The ``/config/local.php`` file contains available configuration parameters, once you save the global configuration form for the first time. This file contains the complete list of settings that are accessible using ``configGetParameter``.
 
 Identifying parameter names
 ---------------------------

--- a/docs/design/retriving_system_information.rst
+++ b/docs/design/retriving_system_information.rst
@@ -41,7 +41,7 @@ For example, to display the API OAuth2 access token lifetime:
 Finding available parameters
 ----------------------------
 
-All available configuration parameters can be found in the ``/config/local.php`` file. This file contains the complete list of settings that can be accessed using ``configGetParameter``.
+All available configuration parameters can be found in the ``/config/local.php`` file once you save the global configuration form for the first time. This file contains the complete list of settings that can be accessed using ``configGetParameter``.
 
 Identifying parameter names
 ---------------------------

--- a/docs/design/retriving_system_information.rst
+++ b/docs/design/retriving_system_information.rst
@@ -1,0 +1,70 @@
+Retrieving Mautic settings in Twig
+=============================================
+
+Mautic allows you to access configuration settings directly in Twig templates using the ``configGetParameter`` function. This feature is particularly useful for creating display conditions or showing existing data in your templates.
+
+Basic usage
+-----------
+
+To retrieve a setting, use the ``configGetParameter`` function with the parameter name as its argument:
+
+.. code-block:: twig
+
+   {{ configGetParameter('parameter_name') }}
+
+Display conditions
+------------------
+
+You can use ``configGetParameter`` in conditional statements to control the display of content based on configuration settings:
+
+.. code-block:: twig
+
+   {% if configGetParameter('ip_lookup_auth') %}
+       <!-- Content to display if ip_lookup_auth is enabled or has a filled value -->
+   {% endif %}
+
+Displaying configuration values
+-------------------------------
+
+To directly display a configuration value in your template, use the following syntax:
+
+.. code-block:: twig
+
+   {{ configGetParameter('parameter_name') }}
+
+For example, to display the API OAuth2 access token lifetime:
+
+.. code-block:: twig
+
+   API OAuth2 Access Token Lifetime: {{ configGetParameter('api_oauth2_access_token_lifetime') }}
+
+Finding available parameters
+----------------------------
+
+All available configuration parameters can be found in the ``/config/local.php`` file. This file contains the complete list of settings that can be accessed using ``configGetParameter``.
+
+Identifying parameter names
+---------------------------
+
+To find the correct parameter name for a specific setting:
+
+1. Inspect the HTML of the setting field in the Mautic interface.
+2. Look for the ``name`` attribute of the input field.
+3. The parameter name will be the last part of the ``name`` attribute value.
+
+For example, if you see:
+
+.. code-block:: html
+
+   <input name="config[apiconfig][api_oauth2_access_token_lifetime]" ...>
+
+The corresponding parameter name would be ``api_oauth2_access_token_lifetime``.
+
+Additional information
+----------------------
+
+- Be cautious when displaying sensitive configuration data in templates.
+- Avoid excessive use of ``configGetParameter`` in loops or frequently rendered templates to prevent performance issues.
+- Always consider providing default values when using configuration parameters to handle cases where the setting might not be defined.
+
+Using the ``configGetParameter`` function in Twig, you can create new interactive experiences in Mautic.

--- a/docs/design/retriving_system_information.rst
+++ b/docs/design/retriving_system_information.rst
@@ -15,7 +15,7 @@ To retrieve a setting, use the ``configGetParameter`` function with the paramete
 Display conditions
 ------------------
 
-You can use ``configGetParameter`` in conditional statements to control the display of content based on configuration settings:
+Use ``configGetParameter`` in conditional statements to control the display of content based on configuration settings:
 
 .. code-block:: twig
 
@@ -32,7 +32,7 @@ To directly display a configuration value in your template, use the following sy
 
    {{ configGetParameter('parameter_name') }}
 
-You can also define the default value as a second parameter:
+It's also possible to define the default value as a second parameter:
 
 .. code-block:: twig
 
@@ -47,7 +47,7 @@ For example, to display the API OAuth2 access token lifetime:
 Finding available parameters
 ----------------------------
 
-All available configuration parameters can be found in the ``/config/local.php`` file once you save the global configuration form for the first time. This file contains the complete list of settings that can be accessed using ``configGetParameter``.
+All available configuration parameters are located in the ``/config/local.php`` file once you save the global configuration form for the first time. This file contains the complete list of settings that are accessible using ``configGetParameter``.
 
 Identifying parameter names
 ---------------------------
@@ -56,7 +56,7 @@ To find the correct parameter name for a specific setting:
 
 1. Inspect the HTML of the setting field in the Mautic interface.
 2. Look for the ``name`` attribute of the input field.
-3. The parameter name will be the last part of the ``name`` attribute value.
+3. The parameter name is the last part of the ``name`` attribute value.
 
 For example, if you see:
 
@@ -70,6 +70,6 @@ Additional information
 ----------------------
 
 - Be cautious when displaying sensitive configuration data in templates.
-- Always consider providing default values when using configuration parameters to handle cases where the setting might not be defined.
+- Always consider providing default values when using configuration parameters to handle cases where the setting aren't defined.
 
 Using the ``configGetParameter`` function in Twig, you can create new interactive experiences in Mautic.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,13 @@ There are several ways to support Mautic other than contributing with code.
 
 .. toctree::
    :maxdepth: 2
+   :caption: Design and UX
+   :hidden:
+
+   design/retrieving_system_settings
+
+.. toctree::
+   :maxdepth: 2
    :caption: Themes
    :hidden:
 
@@ -160,6 +167,6 @@ There are several ways to support Mautic other than contributing with code.
 Indices and tables
 ==================
 
-* :ref:`genindex` 
+* :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`


### PR DESCRIPTION
This PR shows how to check system settings using Twig. This allows to create experiences like showing a banner to remember the user to connect their email account to enable Mautic for sending emails if the system detects that it's not set up yet.