### PR TITLE
Create funding-manifest-urls

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://github.com/mautic/mautic/blob/5.x/funding.json


### PR DESCRIPTION
In applying for the FOSS Funding, we needed to make a funding.json which includes the Dev Docs as a project.

To link to this repo we have to make a .well-known folder with a file which links to the manifest, documented here: https://floss.fund/funding-manifest/.

This PR adds that file/directory.