### PR TITLE
docs: updated documentation for MVC component.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,6 +123,7 @@ There are several ways to support Mautic other than contributing with code.
    plugins/translations
    plugins/continuous-integration
    plugins/from-4-to-5
+   plugins/MVC
 
 .. toctree::
    :maxdepth: 2

--- a/docs/plugins/config.rst
+++ b/docs/plugins/config.rst
@@ -704,19 +704,21 @@ Configure parameters that are consumable through Mautic's ``CoreParameterHelper`
 
 Custom config parameters
 ************************
-Mautic plugins can define custom configuration parameters for use within their code. These parameters are typically stored in ``app/config/local.php``, and their default values should be defined in the plugin’s own config file to ensure stability and avoid errors.
+You can define custom configuration parameters in your plugin to support configurable features, such as enabling or disabling functionality.
 
-To prevent Symfony from throwing errors during cache compilation, or when accessing parameters directly from the container without checking for existence, always define custom parameters in the `plugin’s config file <https://devdocs.mautic.org/en/latest/plugins/config.html#parameters-config-items>`_. This guarantees the parameter exists and has a fallback value.
+Mautic plugins allow you to define these parameters for use within your plugin’s code. Store these parameters in ``app/config/local.php``, and define their default values in the plugin’s own config file to ensure stability and avoid errors. 
 
-To add these configuration options in the Configuration page, you’ll need:
+To avoid errors during cache compilation or when accessing parameters directly from the container without checking for their existence, always define custom parameters in the `plugin’s config file <https://devdocs.mautic.org/en/latest/plugins/config.html#parameters-config-items>`_. This guarantees that the parameter exists and has a fallback value.
 
-- An `event subscriber <https://devdocs.mautic.org/en/latest/plugins/event_listeners.html>`_ to register the configuration,
-- A `form type <https://devdocs.mautic.org/en/latest/components/forms.html>`_ that defines the fields, and
+To add these configuration options in the configuration page, you’ll need:
+
+- An `event subscriber <https://devdocs.mautic.org/en/latest/plugins/event_listeners.html>`_ to register the configuration.
+- A `form type <https://devdocs.mautic.org/en/latest/components/forms.html>`_ that defines the fields.
 - A specific view for rendering the form.
 
 .. note::
 
-   To translate the plugin’s tab label in the Configuration form, include a translation key like ``mautic.config.tab.helloworld_config`` in the plugin’s ``messages.ini`` file. Replace ``helloworld_config`` with the formAlias used when registering the form in the event subscriber.
+   To translate the plugin’s tab label in the configuration form, include a translation key like ``mautic.config.tab.helloworld_config`` in the plugin’s ``messages.ini`` file. Replace ``helloworld_config`` with the ``formAlias`` used when registering the form in the event subscriber.
 
 
 Config event subscriber
@@ -793,15 +795,15 @@ Subscribed events
 The event subscriber listens to the following events:
 
 - ``ConfigEvents::CONFIG_ON_GENERATE``:
-  This event is dispatched when the configuration form is built, allowing the plugin to inject its own tab and configuration options.
+  This event is dispatched when the configuration form is built. This allows the plugin to inject its own tab and configuration options.
 
 - ``ConfigEvents::CONFIG_PRE_SAVE``:
-  This event is triggered before the form values are rendered and saved to the ``local.php`` file. It gives the plugin an opportunity to clean up or manipulate the data before it is written.
+  This event is triggered before the form values are rendered and saved to the ``local.php`` file. This allows the plugin to clean up or modify the data before writing it to ``local.php``.
 
-Handling configuration generation
+Generate plugin configuration
 ---------------------------------
 
-To register the plugin’s configuration details during the ``ConfigEvents::CONFIG_ON_GENERATE`` event, the plugin must call the ``addForm()`` method on the ``ConfigBuilderEvent`` object. The method expects an array with the following elements:
+To register plugin’s configuration details during the ``ConfigEvents::CONFIG_ON_GENERATE event``, call the ``addForm()`` method on the ``ConfigBuilderEvent`` object. The method expects an array with the following elements:
 
 .. list-table::
     :header-rows: 1
@@ -813,23 +815,23 @@ To register the plugin’s configuration details during the ``ConfigEvents::CONF
     * - ``formTheme``
       - The view that formats the configuration form elements, e.g., ``HelloWorldBundle:FormTheme\Config``.
     * - ``parameters``
-      - An array of custom config elements. You can use ``$event->getParametersFromConfig('HelloWorldBundle')`` to retrieve them from the plugin’s config file.
+      - An array of custom configuration elements. ``Use $event->getParametersFromConfig('HelloWorldBundle')`` to retrieve them from the plugin’s configuration file.
 
-Manipulating configuration before save
+Modify configuration before saving
 --------------------------------------
 
-To manipulate or clean up the form data before it is saved, use the ``ConfigEvents::CONFIG_PRE_SAVE`` event. This event is triggered just before the values are saved into the ``local.php`` file. It allows the plugin to adjust the values before they are written.
+To modify the form data before saving, use the ``ConfigEvents::CONFIG_PRE_SAVE event``. This  event is triggered just before values are saved to the ``local.php`` file, allowing the plugin to adjust them.
 
-Registering the subscriber
+Register the event subscriber
 --------------------------
 
-Remember that the subscriber must be registered through the plugin’s configuration in the ``services[events]`` `section <https://devdocs.mautic.org/en/latest/plugins/config.html#service-config-items>`_. This ensures that the plugin listens for the events and reacts accordingly.
+Register the subscriber through the plugin’s configuration in the ``services[events]`` `section <https://devdocs.mautic.org/en/latest/plugins/config.html#service-config-items>`_. This ensures that the plugin listens for the events and reacts accordingly.
 
 
 Config form
 =============
 
-The form type is used to generate the form fields in the main configuration form. Refer to the `Forms documentation <https://devdocs.mautic.org/en/latest/components/forms.html>`_ for more information on using form types.
+The form type is used to generate the form fields in the main configuration form. See the `Forms documentation <https://devdocs.mautic.org/en/latest/components/forms.html>`_ for more information about using form types.
 
 Remember that the form type must be registered through the plugin’s config in the ``services[forms]`` `section <https://devdocs.mautic.org/en/latest/plugins/config.html#service-config-items>`_
 .

--- a/docs/plugins/config.rst
+++ b/docs/plugins/config.rst
@@ -704,51 +704,48 @@ Configure parameters that are consumable through Mautic's ``CoreParameterHelper`
 
 Custom config parameters
 ************************
-You can define custom configuration parameters in your plugin to support configurable features, such as enabling or disabling functionality.
+You can define custom configuration parameters in your Plugin to support configurable features, such as enabling or disabling functions.
 
-Mautic plugins allow you to define these parameters for use within your plugin’s code. Store these parameters in ``app/config/local.php``, and define their default values in the plugin’s own config file to ensure stability and avoid errors. 
+Mautic Plugins allow you to define these parameters for use within your Plugin’s code. Store these parameters in ``config/local.php``, and define their default values in the Plugin’s own config file to ensure stability and avoid errors. 
 
-To avoid errors during cache compilation or when accessing parameters directly from the container without checking for their existence, always define custom parameters in the `plugin’s config file <https://devdocs.mautic.org/en/latest/plugins/config.html#parameters-config-items>`_. This guarantees that the parameter exists and has a fallback value.
+To avoid errors during cache compilation or when accessing parameters directly from the container without checking for their existence, always define custom parameters in the :ref:`plugins/config:Parameters config items`. This guarantees that the parameter exists and has a fallback value.
 
-To add these configuration options in the configuration page, you’ll need:
+To add these configuration options in Mautic's configuration section, you’ll need:
 
-- An `event subscriber <https://devdocs.mautic.org/en/latest/plugins/event_listeners.html>`_ to register the configuration.
-- A `form type <https://devdocs.mautic.org/en/latest/components/forms.html>`_ that defines the fields.
+- An :doc:`event subscriber </plugins/event_listeners>` to register the configuration.
+- A :doc:`Form type </components/forms>` that defines the fields. 
 - A specific view for rendering the form.
 
 .. note::
 
-   To translate the plugin’s tab label in the configuration form, include a translation key like ``mautic.config.tab.helloworld_config`` in the plugin’s ``messages.ini`` file. Replace ``helloworld_config`` with the ``formAlias`` used when registering the form in the event subscriber.
+   To translate the Plugin’s tab label in the configuration form, include a translation key like ``mautic.config.tab.helloworld_config`` in the Plugin’s ``messages.ini`` file. Replace ``helloworld_config`` with the ``formAlias`` used when registering the form in the event subscriber.
 
 
 Config event subscriber
 =======================
 
-This allows plugins to interact with Mautic's configuration events. It listens to two important events: ``ConfigEvents::CONFIG_ON_GENERATE`` and ``ConfigEvents::CONFIG_PRE_SAVE``.
+This allows Plugins to interact with Mautic's configuration events. It listens to two important events: ``ConfigEvents::CONFIG_ON_GENERATE`` and ``ConfigEvents::CONFIG_PRE_SAVE``.
 
-The following code example demonstrates how the event subscriber is structured in a plugin.
+The following code example shows how a Plugin structures its event subscriber.
 
 .. code-block:: php
 
     <?php
-    // plugins/HelloWorldBundle/EventListener/ConfigSubscriber.php
+
+    declare(strict_types=1);
 
     namespace MauticPlugin\HelloWorldBundle\EventListener;
-
     use Mautic\ConfigBundle\Event\ConfigEvent;
-    use Mautic\CoreBundle\EventListener\CommonSubscriber;
     use Mautic\ConfigBundle\ConfigEvents;
     use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-    /**
-     * Class ConfigSubscriber
-     */
-    class ConfigSubscriber extends CommonSubscriber
+    final class ConfigSubscriber extends EventSubscriberInterface
     {
         /**
-         * @return array
+         * @return mixed[]
          */
-        static public function getSubscribedEvents()
+        static public function getSubscribedEvents(): array
         {
             return [
                 ConfigEvents::CONFIG_ON_GENERATE => ['onConfigGenerate', 0],
@@ -756,10 +753,7 @@ The following code example demonstrates how the event subscriber is structured i
             ];
         }
 
-        /**
-         * @param ConfigBuilderEvent $event
-         */
-        public function onConfigGenerate(ConfigBuilderEvent $event)
+        public function onConfigGenerate(ConfigBuilderEvent $event): void
         {
             $event->addForm(
                 [
@@ -770,19 +764,14 @@ The following code example demonstrates how the event subscriber is structured i
             );
         }
 
-        /**
-         * @param ConfigEvent $event
-         */
-        public function onConfigSave(ConfigEvent $event)
+        public function onConfigSave(ConfigEvent $event): void
         {
             /** @var array $values */
             $values = $event->getConfig();
-
             // Manipulate the values
             if (!empty($values['helloworld_config']['custom_config_option'])) {
                 $values['helloworld_config']['custom_config_option'] = htmlspecialchars($values['helloworld_config']['custom_config_option']);
             }
-
             // Set updated values 
             $event->setConfig($values);
         }
@@ -795,15 +784,15 @@ Subscribed events
 The event subscriber listens to the following events:
 
 - ``ConfigEvents::CONFIG_ON_GENERATE``:
-  This event is dispatched when the configuration form is built. This allows the plugin to inject its own tab and configuration options.
+  Mautic dispatches this event when it builds the configuration form. This allows the Plugin to inject its own tab and configuration options.
 
 - ``ConfigEvents::CONFIG_PRE_SAVE``:
-  This event is triggered before the form values are rendered and saved to the ``local.php`` file. This allows the plugin to clean up or modify the data before writing it to ``local.php``.
+  Mautic triggers this event before it renders the form values and saves them to the ``local.php`` file. This allows the Plugin to clean up or modify the data before writing it to ``local.php``.
 
 Generate plugin configuration
----------------------------------
-
-To register plugin’s configuration details during the ``ConfigEvents::CONFIG_ON_GENERATE event``, call the ``addForm()`` method on the ``ConfigBuilderEvent`` object. The method expects an array with the following elements:
+-----------------------------
+.. vale on
+To register Plugin’s configuration details during the ``ConfigEvents::CONFIG_ON_GENERATE event``, call the ``addForm()`` method on the ``ConfigBuilderEvent`` object. The method expects an array with the following elements:
 
 .. list-table::
     :header-rows: 1
@@ -813,33 +802,33 @@ To register plugin’s configuration details during the ``ConfigEvents::CONFIG_O
     * - ``formAlias``
       - The alias of the form type class that defines the expected form elements.
     * - ``formTheme``
-      - The view that formats the configuration form elements, e.g., ``HelloWorldBundle:FormTheme\Config``.
+      - The view that formats the configuration form elements, for example, ``HelloWorldBundle:FormTheme\Config``.
     * - ``parameters``
       - An array of custom configuration elements. ``Use $event->getParametersFromConfig('HelloWorldBundle')`` to retrieve them from the plugin’s configuration file.
+.. vale off
 
 Modify configuration before saving
---------------------------------------
+----------------------------------
 
-To modify the form data before saving, use the ``ConfigEvents::CONFIG_PRE_SAVE event``. This  event is triggered just before values are saved to the ``local.php`` file, allowing the plugin to adjust them.
+To modify the form data before saving, use the ``ConfigEvents::CONFIG_PRE_SAVE event``. This  event is triggered just before values are saved to the ``local.php`` file, allowing the Plugin to adjust them.
 
 Register the event subscriber
---------------------------
+-----------------------------
 
-Register the subscriber through the plugin’s configuration in the ``services[events]`` `section <https://devdocs.mautic.org/en/latest/plugins/config.html#service-config-items>`_. This ensures that the plugin listens for the events and reacts accordingly.
+Register the subscriber through the Plugin’s configuration in the ``services[events]`` in :ref:`plugins/config:Service config items`. This ensures that the plugin listens for the events and reacts accordingly.
 
 
 Config form
-=============
+===========
 
-The form type is used to generate the form fields in the main configuration form. See the `Forms documentation <https://devdocs.mautic.org/en/latest/components/forms.html>`_ for more information about using form types.
+The form type is used to generate the form fields in the main configuration form. See the :doc:`Forms documentation</components/forms>` for more information about using form types.
 
-Remember that the form type must be registered through the plugin’s config in the ``services[forms]`` `section <https://devdocs.mautic.org/en/latest/plugins/config.html#service-config-items>`_
+Remember that the form type must be registered through the Plugin’s config in the ``services[forms]`` in :ref:`plugins/config:Service config items`
 .
 
-Below is an example of a form type class that adds a custom configuration option to the plugin's configuration form.
+Below is an example of a form type class that adds a custom configuration option to the Plugin's configuration form.
 
 .. code-block:: php
-
     <?php
     // plugins/HelloWorldBundle/Form/Type/ConfigType.php
 
@@ -848,66 +837,49 @@ Below is an example of a form type class that adds a custom configuration option
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\FormBuilderInterface;
 
-    /**
-     * Class ConfigType
-     */
-    class ConfigType extends AbstractType
+    final class ConfigType extends AbstractType
     {
         /**
-         * @param FormBuilderInterface $builder
-         * @param array                $options
+         * @param mixed[] $options
          */
-        public function buildForm(FormBuilderInterface $builder, array $options)
+        public function buildForm(FormBuilderInterface $builder, array $options): void
         {
             $builder->add(
                 'custom_config_option',
                 'text',
-                array(
+                [
                     'label' => 'plugin.helloworld.config.custom_config_option',
                     'data'  => $options['data']['custom_config_option'],
-                    'attr'  => array(
+                    'attr'  => [
                         'tooltip' => 'plugin.helloworld.config.custom_config_option_tooltip'
-                    )
-                )
+                    ]
+                ]
             );
-        }
-
-        /**
-         * {@inheritdoc}
-         */
-        public function getName()
-        {
-            return 'helloworld_config';
         }
     }
 
 Config template
-=============
+===============
 
-Registering a form theme as ``HelloWorldBundle:FormTheme\Config`` in the event listener tells the ConfigBundle to look in the HelloWorldBundle’s ``Views/FormTheme/Config`` folder for templates. Specifically, it will look for a template named ``_config_{formAlias}_widget.html.php``, where ``{formAlias}`` is the same as the ``formAlias`` set in the plugin’s ``ConfigEvents::CONFIG_ON_GENERATE`` event listener.
+Registering a form theme as ``HelloWorldBundle:FormTheme\Config`` in the event listener tells the ConfigBundle to look in the HelloWorldBundle’s ``Resources/views/FormTheme/Config`` folder for templates. Specifically, it will look for a template named ``_config_{formAlias}_widget.html.twig``, where ``{formAlias}`` is the same as the ``formAlias`` set in the Plugin’s ``ConfigEvents::CONFIG_ON_GENERATE`` event listener.
 
 The template should be structured in a panel format to match the rest of the configuration UI.
 
 Below is an example of how the template should be structured:
 
-.. code-block:: php
-
-    <?php
-    // plugins/HelloWorldBundle/Views/FormTheme/Config/_config_helloworld_config_widget.html.php
-
-    ?>
-
+.. code-block:: twig  
+    {# plugins/HelloWorldBundle/Views/FormTheme/Config/_config_helloworld_config_widget.html.twig #}  
     <div class="panel panel-primary">
         <div class="panel-heading">
-            <h3 class="panel-title"><?php echo $view['translator']->trans('mautic.config.tab.helloworld_config'); ?></h3>
+            <h3 class="panel-title">{{ 'mautic.config.tab.helloworld_config'|trans }}</h3> 
         </div>
-        <div class="panel-body">
-            <?php foreach ($form->children as $f): ?>
-                <div class="row">
-                    <div class="col-md-6">
-                        <?php echo $view['form']->row($f); ?>
-                    </div>
-                </div>
-            <?php endforeach; ?>
-        </div>
-    </div>
+        <div class="panel-body">  
+            {% for field in form.children %}  
+                <div class="row">  
+                    <div class="col-md-6">  
+                        {{ form_row(field) }}  
+                    </div>  
+                </div>  
+            {% endfor %}  
+        </div>  
+    </div>  

--- a/docs/plugins/config.rst
+++ b/docs/plugins/config.rst
@@ -700,3 +700,212 @@ Configure parameters that are consumable through Mautic's ``CoreParameterHelper`
 .. note:: The default value must match the value's type for Mautic to typecast and transform appropriately. For example, if there isn't a specific default value to declare, define an empty array, ``[]``, for an array type; zero, ``0``, for an integer type; ``TRUE`` or ``FALSE`` for boolean types; and so forth. Services leveraging parameters should accept and handle ``NULL`` for integer and string types, excluding ``0``.
 
 .. note:: Parameters aren't exposed to the UI by default. See :ref:`components/config:Configuration` for more information.
+
+
+Custom config parameters
+************************
+Mautic plugins can define custom configuration parameters for use within their code. These parameters are typically stored in ``app/config/local.php``, and their default values should be defined in the plugin’s own config file to ensure stability and avoid errors.
+
+To prevent Symfony from throwing errors during cache compilation, or when accessing parameters directly from the container without checking for existence, always define custom parameters in the `plugin’s config file <https://devdocs.mautic.org/en/latest/plugins/config.html#parameters-config-items>`_. This guarantees the parameter exists and has a fallback value.
+
+To add these configuration options in the Configuration page, you’ll need:
+
+- An `event subscriber <https://devdocs.mautic.org/en/latest/plugins/event_listeners.html>`_ to register the configuration,
+- A `form type <https://devdocs.mautic.org/en/latest/components/forms.html>`_ that defines the fields, and
+- A specific view for rendering the form.
+
+.. note::
+
+   To translate the plugin’s tab label in the Configuration form, include a translation key like ``mautic.config.tab.helloworld_config`` in the plugin’s ``messages.ini`` file. Replace ``helloworld_config`` with the formAlias used when registering the form in the event subscriber.
+
+
+Config event subscriber
+=======================
+
+This allows plugins to interact with Mautic's configuration events. It listens to two important events: ``ConfigEvents::CONFIG_ON_GENERATE`` and ``ConfigEvents::CONFIG_PRE_SAVE``.
+
+The following code example demonstrates how the event subscriber is structured in a plugin.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/ConfigSubscriber.php
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\ConfigBundle\Event\ConfigEvent;
+    use Mautic\CoreBundle\EventListener\CommonSubscriber;
+    use Mautic\ConfigBundle\ConfigEvents;
+    use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
+
+    /**
+     * Class ConfigSubscriber
+     */
+    class ConfigSubscriber extends CommonSubscriber
+    {
+        /**
+         * @return array
+         */
+        static public function getSubscribedEvents()
+        {
+            return [
+                ConfigEvents::CONFIG_ON_GENERATE => ['onConfigGenerate', 0],
+                ConfigEvents::CONFIG_PRE_SAVE    => ['onConfigSave', 0]
+            ];
+        }
+
+        /**
+         * @param ConfigBuilderEvent $event
+         */
+        public function onConfigGenerate(ConfigBuilderEvent $event)
+        {
+            $event->addForm(
+                [
+                    'formAlias'  => 'helloworld_config',
+                    'formTheme'  => 'HelloWorldBundle:FormTheme\Config',
+                    'parameters' => $event->getParametersFromConfig('HelloWorldBundle')
+                ]
+            );
+        }
+
+        /**
+         * @param ConfigEvent $event
+         */
+        public function onConfigSave(ConfigEvent $event)
+        {
+            /** @var array $values */
+            $values = $event->getConfig();
+
+            // Manipulate the values
+            if (!empty($values['helloworld_config']['custom_config_option'])) {
+                $values['helloworld_config']['custom_config_option'] = htmlspecialchars($values['helloworld_config']['custom_config_option']);
+            }
+
+            // Set updated values 
+            $event->setConfig($values);
+        }
+    }
+
+
+Subscribed events
+-----------------
+
+The event subscriber listens to the following events:
+
+- ``ConfigEvents::CONFIG_ON_GENERATE``:
+  This event is dispatched when the configuration form is built, allowing the plugin to inject its own tab and configuration options.
+
+- ``ConfigEvents::CONFIG_PRE_SAVE``:
+  This event is triggered before the form values are rendered and saved to the ``local.php`` file. It gives the plugin an opportunity to clean up or manipulate the data before it is written.
+
+Handling configuration generation
+---------------------------------
+
+To register the plugin’s configuration details during the ``ConfigEvents::CONFIG_ON_GENERATE`` event, the plugin must call the ``addForm()`` method on the ``ConfigBuilderEvent`` object. The method expects an array with the following elements:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Key
+      - Description
+    * - ``formAlias``
+      - The alias of the form type class that defines the expected form elements.
+    * - ``formTheme``
+      - The view that formats the configuration form elements, e.g., ``HelloWorldBundle:FormTheme\Config``.
+    * - ``parameters``
+      - An array of custom config elements. You can use ``$event->getParametersFromConfig('HelloWorldBundle')`` to retrieve them from the plugin’s config file.
+
+Manipulating configuration before save
+--------------------------------------
+
+To manipulate or clean up the form data before it is saved, use the ``ConfigEvents::CONFIG_PRE_SAVE`` event. This event is triggered just before the values are saved into the ``local.php`` file. It allows the plugin to adjust the values before they are written.
+
+Registering the subscriber
+--------------------------
+
+Remember that the subscriber must be registered through the plugin’s configuration in the ``services[events]`` `section <https://devdocs.mautic.org/en/latest/plugins/config.html#service-config-items>`_. This ensures that the plugin listens for the events and reacts accordingly.
+
+
+Config form
+=============
+
+The form type is used to generate the form fields in the main configuration form. Refer to the `Forms documentation <https://devdocs.mautic.org/en/latest/components/forms.html>`_ for more information on using form types.
+
+Remember that the form type must be registered through the plugin’s config in the ``services[forms]`` `section <https://devdocs.mautic.org/en/latest/plugins/config.html#service-config-items>`_
+.
+
+Below is an example of a form type class that adds a custom configuration option to the plugin's configuration form.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Form/Type/ConfigType.php
+
+    namespace MauticPlugin\HelloWorldBundle\Form\Type;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilderInterface;
+
+    /**
+     * Class ConfigType
+     */
+    class ConfigType extends AbstractType
+    {
+        /**
+         * @param FormBuilderInterface $builder
+         * @param array                $options
+         */
+        public function buildForm(FormBuilderInterface $builder, array $options)
+        {
+            $builder->add(
+                'custom_config_option',
+                'text',
+                array(
+                    'label' => 'plugin.helloworld.config.custom_config_option',
+                    'data'  => $options['data']['custom_config_option'],
+                    'attr'  => array(
+                        'tooltip' => 'plugin.helloworld.config.custom_config_option_tooltip'
+                    )
+                )
+            );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getName()
+        {
+            return 'helloworld_config';
+        }
+    }
+
+Config template
+=============
+
+Registering a form theme as ``HelloWorldBundle:FormTheme\Config`` in the event listener tells the ConfigBundle to look in the HelloWorldBundle’s ``Views/FormTheme/Config`` folder for templates. Specifically, it will look for a template named ``_config_{formAlias}_widget.html.php``, where ``{formAlias}`` is the same as the ``formAlias`` set in the plugin’s ``ConfigEvents::CONFIG_ON_GENERATE`` event listener.
+
+The template should be structured in a panel format to match the rest of the configuration UI.
+
+Below is an example of how the template should be structured:
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Views/FormTheme/Config/_config_helloworld_config_widget.html.php
+
+    ?>
+
+    <div class="panel panel-primary">
+        <div class="panel-heading">
+            <h3 class="panel-title"><?php echo $view['translator']->trans('mautic.config.tab.helloworld_config'); ?></h3>
+        </div>
+        <div class="panel-body">
+            <?php foreach ($form->children as $f): ?>
+                <div class="row">
+                    <div class="col-md-6">
+                        <?php echo $view['form']->row($f); ?>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>

--- a/docs/plugins/mvc.rst
+++ b/docs/plugins/mvc.rst
@@ -1,0 +1,635 @@
+MVC
+###
+
+Mautic uses a **Model-View-Controller (MVC)** structure to manage how users interact with the frontend (**views**) and how those interactions are handled by the backend (**controllers and models**). Additionally, **Entity** and **Repository** classes are used to manage interactions with the database.
+
+In Symfony — and therefore in Mautic — the **controller** is the central part of the MVC structure. When a user makes a request, the route determines which controller method is executed. The controller then interacts with the **model** to retrieve or manipulate data, and finally renders a **view** to display the results to the user.
+
+Controllers
+===========
+Matching Routes to controller methods
+-------------------------------------
+
+The controller method called is determined by the route defined in the config. Take this example:
+
+.. code-block:: php
+
+    'plugin_helloworld_admin' => array(
+        'path'       => '/hello/admin',
+        'controller' => 'HelloWorldBundle:Default:admin'
+    ),
+
+The controller is noted as ``HelloWorldBundle:Default:admin``. Broken down, that translates to:
+
+- ``HelloWorldBundle`` → ``\MauticPlugin\HelloWorldBundle\Controller``
+- ``Default`` → ``DefaultController``
+- ``admin`` → ``adminAction()``
+
+Controller notation follows the format: ::
+
+    BundleName:ControllerName:controllerMethod
+
+To use a controller within a subfolder of ``Controller``, use this format: ::
+
+    BundleName:Subdirectory\ControllerName:controllerMethod
+
+Thus, when a browser calls up ``/hello/admin``, ``\MauticPlugin\HelloWorldBundle\Controller\DefaultController::adminAction()`` will be called.
+
+Route placeholders
+------------------
+
+Symfony automatically passes route placeholders into the controller’s method as arguments. The method’s parameters must match the placeholder names.
+
+Example:
+
+.. code-block:: php
+
+    'plugin_helloworld_world' => array(
+        'path'       => '/hello/{world}',
+        'controller' => 'HelloWorldBundle:Default:world',
+        'defaults'    => array(
+            'world' => 'earth'
+        ),
+        'requirements' => array(
+            'world' => 'earth|mars'
+        )
+    ),
+
+The matching method:
+
+.. code-block:: php
+
+    public function worldAction($world = 'earth')
+
+Notice: Since the route defines a default for ``world``, the controller method must also reflect this default.
+
+If the route looked like this instead:
+
+.. code-block:: php
+
+    'plugin_helloworld_world' => array(
+        'path'       => '/hello/{world}',
+        'controller' => 'HelloWorldBundle:Default:world',
+        'requirements' => array(
+            'world' => 'earth|mars'
+        )
+    ),
+
+Then the method must be:
+
+.. code-block:: php
+
+    public function worldAction($world)
+
+Extending Mautic’s Controllers
+------------------------------
+
+Mautic has several controllers that provide some helper functions.
+
+``Mautic\CoreBundle\Controller\CommonController``
+-------------------------------------------------
+
+Controllers extending this will make ``MauticFactory`` available via ``$this->factory`` and ``Request`` via ``$this->request``.
+
+It also provides the following helper methods:
+
+**delegateView($args)**  
+Mautic is ajax driven and thus must support both http requests and ajax requests for content.  
+``delegateView`` is a wrapper method that determines if the request is for ajax content or the full DOM, then generates and returns the appropriate response.
+
+The ``$args`` argument is an array with the required elements for generating the view, ajax or http.  
+It will accept the following parameters:
+
+.. list-table:: Parameters for ``delegateView()``
+   :widths: 20 10 10 60
+   :header-rows: 1
+
+   * - Key
+     - Required
+     - Type
+     - Description
+   * - contentTemplate
+     - REQUIRED
+     - string
+     - Defines the view template to load. This should be in view notation of ``BundleName:ViewName:template.html.php``. Refer to views for more info.
+   * - viewParameters
+     - OPTIONAL
+     - array
+     - Array of variables with values made available to the template. Each key will be a variable available to the template.
+   * - passthroughVars
+     - OPTIONAL
+     - array
+     - Array of variables returned as part of the ajax response used by Mautic and/or the plugin’s onLoad JS callback.
+
+Due to the use of ajax, there are some elements of the ``passthroughVars`` array that Mautic will use internally to manipulate the user interface.  
+For responses that include main content (i.e., routes a user would click to), you should set at least ``activeLink`` and ``route``.
+
+.. list-table:: Common passthroughVars
+   :widths: 20 10 10 60
+   :header-rows: 1
+
+   * - Key
+     - Required
+     - Type
+     - Description
+   * - activeLink
+     - OPTIONAL
+     - string
+     - The ID of the menu item that should be activated dynamically to match ajax response.
+   * - route
+     - OPTIONAL
+     - string
+     - The route that should be pushed to the browser’s address bar to match ajax response.
+   * - mauticContent
+     - OPTIONAL
+     - string
+     - Used to generate the JS method to call after ajax content is injected into the DOM. If set as ``helloWorldDetails``, Mautic will check for and execute ``Mautic.helloWorldDetailsOnLoad()``.
+   * - callback
+     - OPTIONAL
+     - string
+     - A Mautic namespaced JS function executed before response is injected. If set, Mautic passes the response to this function and does not process content.
+   * - redirect
+     - OPTIONAL
+     - string
+     - The URL to force a page redirect instead of injecting ajax content.
+   * - target
+     - OPTIONAL
+     - string
+     - jQuery selector to inject the content into. Defaults to app’s main content selector.
+   * - replaceContent
+     - OPTIONAL
+     - string
+     - If set to `'true'`, Mautic will replace the target selector with ajax content.
+
+**delegateRedirect($url)**  
+Delegates the appropriate response for redirects.  
+If ajax request: returns a json response with ``{redirect: $url}``.  
+If http request: performs a standard redirect header.
+
+**postActionRedirect($args)**  
+Similar to ``delegateView()``, but used after an action like saving a form.  
+Accepts the same ``$args`` as ``delegateView()``, plus:
+
+.. list-table:: Additional Parameters for ``postActionRedirect()``
+   :widths: 20 10 10 60
+   :header-rows: 1
+
+   * - Key
+     - Required
+     - Type
+     - Description
+   * - returnUrl
+     - OPTIONAL
+     - string
+     - URL to redirect to. Defaults to ``/s/dashboard``. Auto-populates ``passthroughVars[route]`` if not set.
+   * - flashes
+     - OPTIONAL
+     - array
+     - Array of flash messages to display after redirecting.
+   * - forwardController
+     - OPTIONAL
+     - bool
+     - If true (default), forwards to a controller method. If false, directly loads a view template.
+
+
+FormController
+--------------
+
+Extends ``CommonController``.
+
+``Mautic\CoreBundle\Controller\FormController``. This controller extends ``CommonController`` and provides helper methods for managing forms :doc:`Forms <components/forms>`.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Controller/DefaultController.php
+
+    namespace MauticPlugin\HelloWorldBundle\Controller;
+
+    use Mautic\CoreBundle\Controller\FormController;
+
+    class DefaultController extends FormController
+    {
+        /**
+         * Display the world view
+         *
+         * @param string $world
+         *
+         * @return JsonResponse|\Symfony\Component\HttpFoundation\Response
+         */
+        public function worldAction($world = 'earth')
+        {
+            /** @var \MauticPlugin\HelloWorldBundle\Model\WorldModel $model */
+            $model = $this->getModel('helloworld.world');
+
+            // Retrieve details about the world
+            $worldDetails = $model->getWorldDetails($world);
+
+            return $this->delegateView(
+                array(
+                    'viewParameters'  => array(
+                        'world'   => $world,
+                        'details' => $worldDetails
+                    ),
+                    'contentTemplate' => 'HelloWorldBundle:World:details.html.php',
+                    'passthroughVars' => array(
+                        'activeLink'    => 'plugin_helloworld_world',
+                        'route'         => $this->generateUrl('plugin_helloworld_world', array('world' => $world)),
+                        'mauticContent' => 'helloWorldDetails'
+                    )
+                )
+            );
+        }
+
+        /**
+         * Contact form
+         *
+         * @return JsonResponse|\Symfony\Component\HttpFoundation\Response
+         */
+        public function contactAction()
+        {
+            // Create the form object
+            $form = $this->get('form.factory')->create('helloworld_contact');
+
+            // Handle form submission if POST        
+            if ($this->request->getMethod() == 'POST') {
+                $flashes = array();
+
+                // isFormCancelled() checks if the cancel button was clicked
+                if ($cancelled = $this->isFormCancelled($form)) {
+
+                    // isFormValid() will bind the request to the form object and validate the data
+                    if ($valid = $this->isFormValid($form)) {
+
+                        /** @var \MauticPlugin\HelloWorldBundle\Model\ContactModel $model */
+                        $model = $this->getModel('helloworld.contact');
+
+                        // Send the email
+                        $model->sendContactEmail($form->getData());
+
+                        // Set success flash message
+                        $flashes[] = array(
+                            'type'    => 'notice',
+                            'msg'     => 'plugin.helloworld.notice.thank_you',
+                            'msgVars' => array(
+                                '%name%' => $form['name']->getData()
+                            )
+                        );
+                    }
+                }
+
+                if ($cancelled || $valid) {
+                    // Redirect to /hello/world
+
+                    return $this->postActionRedirect(
+                        array(
+                            'returnUrl'       => $this->generateUrl('plugin_helloworld_world'),
+                            'contentTemplate' => 'HelloWorldBundle:Default:world',
+                            'flashes'         => $flashes
+                        )
+                    );
+                } // Otherwise show the form again with validation error messages
+            }
+
+            // Display the form
+            return $this->delegateView(
+                array(
+                    'viewParameters'  => array(
+                        'form' => $form->createView()
+                    ),
+                    'contentTemplate' => 'HelloWorldBundle:Contact:form.html.php',
+                    'passthroughVars' => array(
+                        'activeLink' => 'plugin_helloworld_contact',
+                        'route'      => $this->generateUrl('plugin_helloworld_contact')
+                    )
+                )
+            );
+        }
+    }
+
+
+AjaxController
+--------------
+
+``Mautic\CoreBundle\Controller\AjaxController``. This controller also extends ``CommonController`` and is a companion to some of the built-in Javascript helpers. See *Javascript methods* for more information.
+
+Models
+======
+
+Models are used to retrieve and process data between controllers and views. While not required in plugins, Mautic provides convenient ways to access model objects and use commonly needed methods if you choose to use them.
+
+Model Example
+-------------
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Model/ContactModel.php
+
+    namespace MauticPlugin\HelloWorldBundle\Model;
+
+    use Mautic\CoreBundle\Model\CommonModel;
+
+    class ContactModel extends CommonModel
+    {
+        /**
+         * Send contact email
+         * 
+         * @param array $data
+         */
+        public function sendContactEmail($data)
+        {
+            // Get mailer helper - pass the mautic.helper.mailer service as a dependency
+            $mailer = $this->mailer;
+
+            $mailer->message->addTo(
+                $this->factory->getParameter('mailer_from_email')
+            );
+
+            $this->message->setFrom(
+                array($data['email'] => $data['name'])
+            );
+
+            $mailer->message->setSubject($data['subject']);
+
+            $mailer->message->setBody($data['message']);
+
+            $mailer->send();
+        }
+    }
+
+Registering Model Classes
+-------------------------
+
+Models should be registered as model services. The service name must follow the format:
+
+``mautic.UNIQUE_BUNDLE_IDENTIFIER.model.MODEL_IDENTIFIER``
+
+- ``UNIQUE_BUNDLE_IDENTIFIER``: Any unique name for your plugin or bundle
+- ``MODEL_IDENTIFIER``: A name unique within the bundle
+
+For example, the model shown above could be registered as:
+
+``mautic.helloworld.model.contact``
+
+This allows Mautic’s helper functions to retrieve the model using the `getModel()` method.
+
+Base Model Classes
+------------------
+
+You can extend either of the following base classes to make use of Mautic's helper methods:
+
+**\Mautic\CoreBundle\Model\AbstractCommonModel**
+
+This base class offers access to services commonly used in models:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Property
+      - Service
+      - Description
+    * - ``$this->factory``
+      - Factory service
+      - Provides access to other Mautic services. *Deprecated as of Mautic 2.0*; use dependency injection instead.
+    * - ``$this->em``
+      - Entity manager
+      - Handles database interactions via Doctrine.
+    * - ``$this->security``
+      - Security service
+      - Provides access to the current user and permission checks.
+    * - ``$this->dispatcher``
+      - Event dispatcher
+      - Dispatches and listens for Mautic events.
+    * - ``$this->translator``
+      - Translator service
+      - Handles language translations.
+
+
+**\Mautic\CoreBundle\Model\FormModel**
+
+This extends ``AbstractCommonModel`` and includes helper methods for working with entities and repositories. For more information, see the :doc:`Database <components/entities>` section.
+
+Getting Model Objects
+---------------------
+
+To retrieve a model object in a controller:
+
+.. code-block:: php
+
+    <?php
+
+    /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
+    $leadModel = $this->getModel('lead'); // Shortcut for lead.lead
+
+    /** @var \Mautic\LeadBundle\Model\ListModel $leadListModel */
+    $leadListModel = $this->getModel('lead.list');
+
+    /** @var \MauticPlugin\HelloWorldBundle\Model\ContactModel $contactModel */
+    $contactModel = $this->getModel('helloworld.contact');
+
+If using a model inside another service or model, inject the model service as a dependency instead of using the helper method.
+
+Views
+=====
+
+Views in Mautic take data passed from the Controller and display it to the user. Templates can be rendered from within controllers or other templates.
+
+Example Template Files
+----------------------
+
+**`details.html.php`**
+
+.. code-block:: php
+
+    // plugins/HelloWorldBundle/Views/World/details.html.php
+
+    if (!$app->getRequest()->isXmlHttpRequest()) {
+        $view['slots']->set('tmpl', 'Details');
+        $view->extend('HelloWorldBundle:World:index.html.php');
+    }
+    
+    <div>
+        <!-- Desired content/markup -->
+    </div>
+
+**`index.html.php`**
+
+.. code-block:: php
+
+    // plugins/HelloWorldBundle/Views/World/index.html.php
+
+    $view->extend('MauticCoreBundle:Default:content.html.php');
+
+    $tmpl = $view['slots']->get('tmpl', 'Details');
+
+    $view['slots']->set('mauticContent', 'helloWorld' . $tmpl);
+
+    $header = ($tmpl == 'World')
+        ? $view['translator']->trans(
+            'plugin.helloworld.worlds',
+            array('%world%' => ucfirst($world))
+        ) : $view['translator']->trans('plugin.helloworld.manage_worlds');
+    $view['slots']->set('headerTitle', $header);
+    
+    <div class="helloworld-content">
+        <?php $view['slots']->output('_content'); ?>
+    </div>
+
+View Notation
+-------------
+
+View templates follow this format:
+
+.. code-block:: text
+
+    BundleName:ViewName:template.html.php
+
+Nested views can be referenced using backslashes:
+
+.. code-block:: text
+
+    BundleName:ViewName\Subfolder:template.html.php
+
+Rendering Views
+---------------
+
+Use the Controller’s ``delegateView()`` method with the ``contentTemplate`` key to render a view. Variables passed in ``viewParameters`` become available in the template:
+
+.. code-block:: php
+
+    'viewParameters' => array(
+        'world' => 'mars'
+    )
+
+This allows ``$world`` to be used in the view.
+
+Available View Variables
+------------------------
+
+- **$view** — Provides access to template helpers and rendering functions.
+- **$app** — Provides access to the request and session.
+
+Extending Views
+---------------
+
+To extend Mautic’s base templates:
+
+.. code-block:: php
+
+    $view->extend('MauticCoreBundle:Default:content.html.php');
+
+For slim templates (no menu or header):
+
+.. code-block:: php
+
+    $view->extend('MauticCoreBundle:Default:slim.html.php');
+
+For Ajax requests, use:
+
+.. code-block:: php
+
+    $app->getRequest()->isXmlHttpRequest()
+
+Templates render inside-out. So:
+
+1. `details.html.php` is rendered first.
+2. Injected into `index.html.php`.
+3. Finally into `content.html.php`.
+
+Use ``$view['slots']->output('_content');`` to include sub-template content.
+
+Rendering Views Within Views
+----------------------------
+
+You can render one view inside another:
+
+.. code-block:: php
+
+    echo $view->render('BundleName:ViewName:template.html.php', array('parameter' => 'value'));
+
+Template Helpers
+================
+
+Slots Helper
+------------
+
+.. code-block:: php
+
+    $view['slots']->set('name', 'content');
+    $view['slots']->append('name', ' more content');
+    $content = $view['slots']->get('name', 'default');
+    $view['slots']->output('name');
+
+Asset Helper
+------------
+
+.. code-block:: php
+
+    echo '<img src="' . $view['assets']->getUrl('plugins/HelloWorldBundle/assets/images/earth.png') . '" />';
+    echo $view['assets']->includeScript('plugins/HelloWorldBundle/assets/helloworld.js');
+    echo $view['assets']->includeStylesheet('plugins/HelloWorldBundle/assets/helloworld.css');
+
+Router Helper
+-------------
+
+.. code-block:: php
+
+    <a href="<?php echo $view['router']->generate('plugin_helloworld_world', array('world' => 'mars')); ?>" data-toggle="ajax">Mars</a>
+
+Translation Helper
+------------------
+
+.. code-block:: php
+
+    <h1><?php echo $view['translator']->trans('plugin.helloworld.worlds', array('%world%' => 'Mars')); ?></h1>
+
+Date Helper
+-----------
+
+.. code-block:: php
+
+    $datetime = '2015-04-12 20:56:00';
+    $view['date']->toFull($datetime);
+    $view['date']->toShort($datetime);
+    $view['date']->toDate($datetime);
+    $view['date']->toTime($datetime);
+    $view['date']->toFullConcat($datetime);
+    $view['date']->toText($datetime);
+    $view['date']->toFull($datetime, 'Y-m-d H:i:s', 'UTC');
+
+Form Helper
+-----------
+
+.. code-block:: php
+
+    <?php echo $view['form']->form($form); ?>
+
+Ajax Integration
+============
+
+Ajax Links
+----------
+
+.. code-block:: php
+
+    <a href="<?php echo $view['router']->generate('plugin_helloworld_world', array('world' => 'mars')); ?>" data-toggle="ajax">Mars</a>
+
+Ajax Modals
+-----------
+
+.. code-block:: php
+
+    <a href="<?php echo $view['router']->generate('plugin_helloworld_world', array('world' => 'mars')); ?>"
+       data-toggle="ajaxmodal"
+       data-target="#MauticSharedModal"
+       data-header="<?php echo $view['translator']->trans('plugin.helloworld.worlds', array('%world%' => 'Mars')); ?>">
+       Mars
+    </a>
+
+Ajax Forms
+----------
+
+Forms rendered with Symfony form services are auto-ajaxified.
+
+


### PR DESCRIPTION
This PR brings over the documentation for the MVC component, updates it to include new additions, and converts the format to reStructuredText (RST).

It addresses [issue #99](https://github.com/mautic/developer-documentation-new/issues/99).