### PR TITLE
Add support for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "features": {
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "3.11",
+            "installTools": true
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "swyddfa.esbonio",
+                "lextudio.restructuredtext",
+                "eamodio.gitlens",
+                "trond-snekvik.simple-rst"
+            ]
+        }
+    },
+    "postCreateCommand": "chmod +x .devcontainer/setup-project.sh && .devcontainer/setup-project.sh"
+}

--- a/.devcontainer/setup-project.sh
+++ b/.devcontainer/setup-project.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+VALE_VERSION=3.7.1
+
+# Install required packages
+pip install -r docs/requirements.txt
+
+# Required for Vale
+pip install rst2html rstcheck
+
+# Install Vale
+mkdir -p /tmp/vale
+curl -sSL https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz | tar -xz -C /tmp/vale
+sudo install -o root -g root -m 0755 /tmp/vale/vale /usr/local/bin/vale
+rm -rf /tmp/vale

--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-[![Documentation Status][RTD badge URL]][RTD URL]
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mautic/developer-documentation-new)
+[![Documentation Status][RTD badge URL]][RTD URL] [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 
 # Mautic developer documentation (new)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation Status][RTD badge URL]][RTD URL] [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
+[![Documentation Status][RTD badge URL]][RTD URL] [![All Contributors](https://img.shields.io/github/all-contributors/mautic/developer-documentation-new?color=ee8449&style=flat-square)](#contributors)
 
 # Mautic developer documentation (new)
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/13b74237-3578-4c3d-9aa4-f6efc759ef64)

Wait until the "Setting up remote connection: Building codespace..." has finished.

![image](https://github.com/user-attachments/assets/ce194512-274f-4d26-bf16-66303d4384c8)

Once the codespace has been built, a terminal will open and run some post-creation commands (installing required Python packages and Vale). This step is quick.

Next, open any .rst file and click the Preview button at the top right.

![image](https://github.com/user-attachments/assets/0ade075a-f62b-47f7-ab60-e0481a5d10d2)

The preview window will open, but it won’t work. [See here](https://docs.esbon.io/en/latest/lsp/getting-started.html#open-a-preview)
There’s a workaround: opening the preview triggers the Esbonio server to start. Then, under the Ports tab, you’ll see a URL that you can use to view the documentation. Click either of the two buttons - the first opens it in the browser, the second opens it in the editor.

![image](https://github.com/user-attachments/assets/3d3d86d5-acb2-4fc8-abcd-0bca761b2572)

When viewing via the URL, you’ll need to refresh the page after making edits.

https://github.com/user-attachments/assets/8bee11ad-15d1-47bc-821f-34534fd17cc6