### PR TITLE
fix: redis cache config key

### DIFF
--- a/docs/components/cache.rst
+++ b/docs/components/cache.rst
@@ -101,18 +101,18 @@ Delivered adapters
 
 Redis configuration in ``local.php``:
 
-.. code-block:: php
-
-    'redis' => [
-        'dsn' => 'redis://localhost',
-        'options' => [
+.. code-block:: PHP
+    
+    'cache_adapter_redis' => [
+        'dsn' => 'redis://localhost:6379/0',
+        'options' => array(
             'lazy' => false,
             'persistent' => 0,
             'persistent_id' => null,
             'timeout' => 30,
             'read_timeout' => 0,
-            'retry_interval' => 0,
-        ],
+            'retry_interval' => 0
+        ),
     ],
     
 In order to use another adapter, just set it up as a service.

--- a/docs/components/cache.rst
+++ b/docs/components/cache.rst
@@ -105,14 +105,14 @@ Redis configuration in ``local.php``:
     
     'cache_adapter_redis' => [
         'dsn' => 'redis://localhost:6379/0',
-        'options' => array(
+        'options' => [
             'lazy' => false,
             'persistent' => 0,
             'persistent_id' => null,
             'timeout' => 30,
             'read_timeout' => 0,
             'retry_interval' => 0
-        ),
+        ],
     ],
     
 In order to use another adapter, just set it up as a service.

--- a/docs/components/cache.rst
+++ b/docs/components/cache.rst
@@ -88,7 +88,7 @@ Delivered adapters
 
 .. code-block:: php
     
-    'memcached' => [
+    'cache_adapter_memcached' => [
         'servers' => ['memcached://localhost'],
         'options' => [
             'compression' => true,


### PR DESCRIPTION
Based on the setup that i have and have seen [e.g. here](https://forum.mautic.org/t/configuring-memcache-or-redis-in-local-php/27267/20) the cache adapter key is likely incorrect in the docs

Related but less "sure": The memcache key is likely incorrect too [here](https://github.com/mautic/developer-documentation-new/pull/247/files#diff-940badab72fb751990d09984d82aa32b09792ae92d69da4b393ce1c88a49858fR91)