### PR TITLE
Add CODEWONERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# For code owners docs, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global owners
+
+*  @mautic/education-team-leaders


### PR DESCRIPTION
## Description

This PR adds a `CODEOWNERS` file to the `.github` folder with details as below:

- **Global owners**: Education Team Leaders

## Linked Issue

Closes #255 