### PR TITLE
Add sphinx and build capabilities, fixes #258

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,8 @@
+type: generic
+docroot: "docs/build/html"
+working_dir:
+  web: /var/www/html/docs
+omit_containers: [db]
+hooks:
+  post-start:
+    - exec: "make html"

--- a/.ddev/web-build/Dockerfile.sphinx
+++ b/.ddev/web-build/Dockerfile.sphinx
@@ -1,0 +1,8 @@
+RUN apt update || true
+RUN apt install -y build-essential python3.11-venv
+RUN apt remove pipx
+RUN curl -sSL https://github.com/pypa/pipx/releases/latest/download/pipx.pyz -o /usr/local/bin/pipx
+RUN chmod +x /usr/local/bin/pipx
+
+RUN pipx install --global sphinx
+RUN pipx install --force --global --include-deps sphinx-rtd-theme


### PR DESCRIPTION
This adds a DDEV configuration that has 
- sphinx and required dependencies.
- a post-start hook that builds the documentation

After editing, you can `ddev exec make html` to update the html and view in a browser.
