### PR TITLE
Add `build-docs` file to add `ddev build-docs` command

### DIFF
--- a/.ddev/commands/web/build-docs
+++ b/.ddev/commands/web/build-docs
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+## Description: Build User documentation using the Sphinx HTML builder.
+## Usage: build-docs
+## Example: ddev build-docs
+
+# Ensure we fail on error
+set -e
+
+# Initialize terminal colors/styles
+bold=$(tput bold)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+underline=$(tput smul)
+
+echo "${bold}${green}🔧 Building user documentation...${reset}"
+
+# Ensure we're in the right directory
+cd /var/www/html/docs
+echo
+
+# Run the build
+make html
+
+# Success message
+echo
+echo "${green}✅ Documentation build completed successfully!${reset}"
+echo "${green}📁 The HTML pages are in: ${bold}/var/www/html/docs/build/html${reset}"
+
+# Friendly access hint
+echo "${green}🌐 View the documentation at: ${bold}${underline}https://${DDEV_HOSTNAME}${reset}"
+echo


### PR DESCRIPTION
## Description

This PR adds `build-docs` file to the `commands/web` folder to use `ddev build-docs` to build the HTML.

## How to test

1. Pull this PR to your local.
2. Run `ddev start`.
3. Run `ddev build-docs`. It builds the docs.

**As comparison:**

1. In your terminal, navigate to the default `5.x` branch.
2. Run `ddev start`.
3. Run `ddev build-docs`. You should see below error message:

    ```bash
    Error: unknown command "build-docs" for "ddev"
    Run 'ddev --help' for usage.
    ```

4. Run `ddev exec make html`. It builds the docs.

<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

Closes #270 

<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->