### PR TITLE
Fix: Broken link at CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Contributions are always welcome, no matter how large or small, or at whatever s
 
 <!-- vale off -->
 
-Please refer to the "[Contributing to Mautic’s documentation](https://contribute.mautic.org/en/latest/contributing/contributing_docs_rst.html)" page in the Mautic community handbook for detailed instructions on how to contribute to this repository.
+Please refer to the "[Contributing to Mautic’s documentation](https://contribute.mautic.org/en/latest/contributing/contributing_docs.html)" page in the Mautic community handbook for detailed instructions on how to contribute to this repository.
 
 <!-- vale on -->
 


### PR DESCRIPTION
## Description

This PR fixes the broken link in `CONTRIBUTING.md`. Path to the community handbook is changed to https://contribute.mautic.org/en/latest/contributing/contributing_docs.html


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

N/A


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->