### PR TITLE
docs: Clarify that value 0 is valid when setting contact fields via API

### DIFF
--- a/docs/rest_api/contacts.rst
+++ b/docs/rest_api/contacts.rst
@@ -461,6 +461,7 @@ Create a new Contact.
    * - ``overwriteWithBlank``
      - If true, then empty values get set to fields. Otherwise empty values get skipped
 
+.. note:: Mautic only treats ``null`` and empty strings (``''``) as empty values. The value ``0`` - whether integer or string - counts as a valid value and gets saved to the field. This matters when using ``overwriteWithBlank`` or setting numeric fields to zero.
 
 **Response**
 

--- a/docs/rest_api/contacts.rst
+++ b/docs/rest_api/contacts.rst
@@ -461,7 +461,9 @@ Create a new Contact.
    * - ``overwriteWithBlank``
      - If true, then empty values get set to fields. Otherwise empty values get skipped
 
-.. note:: Mautic only treats ``null`` and empty strings (``''``) as empty values. The value ``0`` - whether integer or string - counts as a valid value and gets saved to the field. This matters when using ``overwriteWithBlank`` or setting numeric fields to zero.
+.. note::
+
+   Mautic only treats ``null`` and empty strings - ``''`` - as empty values. The value ``0``, whether integer or string, counts as a valid value and gets saved to the field. This matters when using ``overwriteWithBlank`` or setting numeric fields to zero.
 
 **Response**
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/5a615069-6e81-4698-98d0-f35dcf904138)

Adds a note to the Contacts API documentation explaining that Mautic only treats `null` and empty strings as empty values. The value `0` (integer or string) is a valid value and will be saved to the field. This clarification helps API developers who need to set numeric fields to zero.

### Trigger Events

<details>
<summary><a href="https://github.com/mautic/mautic/pull/15900">mautic/mautic PR #15900: fix: use strict comparison for isEmpty to allow saving value 0 in contact fields</a></summary>
<br>

**Promptless Research** (1 GitHub PR)

- [Reviewed mautic/mautic#15900](https://github.com/mautic/mautic/pull/15900)

**Agent Response**

> I've completed my review of PR #15900 and created a documentation update.
> 
> ## Summary
> 
> **PR #15900** fixes a bug where setting a contact field value to `0` (zero) via the REST API was silently ignored. The root cause was PHP's loose comparison treating `0` as an empty value. With the fix, `0` is now correctly saved as a valid value.
> 
> ## Documentation Update
> 
> I created a suggestion that adds a clarifying note to the Contacts API documentation explaining:
> - Only `null` and empty strings (`''`) are treated as empty values
> - The value `0` (whether integer or string) counts as a valid value and gets saved
> - This is relevant when using `overwriteWithBlank` or setting numeric fields to zero
> 
> **Suggestion**: [Clarify that value 0 is valid when setting contact fields via API](https://app.gopromptless.ai/suggestions/5a615069-6e81-4698-98d0-f35dcf904138)
> 
> **File updated**: `docs/rest_api/contacts.rst`
> 
> This documentation clarification will help API developers understand the expected behavior when working with numeric contact fields and the `overwriteWithBlank` parameter.

</details>



---

_Tip: Use labels in the [Promptless dashboard](https://app.gopromptless.ai) to categorize suggestions by release or team 🏷️_