### PR TITLE
docs: Document withContactCounts parameter for Campaigns API

### DIFF
--- a/docs/rest_api/campaigns.rst
+++ b/docs/rest_api/campaigns.rst
@@ -150,6 +150,12 @@ Get an individual Campaign by ID.
    * - ``events``
      - array
      - Array of Event entities for the Campaign - see below
+   * - ``contactCount``
+     - int
+     - Number of Contacts in the Campaign. Only included when ``withContactCounts`` is set in the request.
+   * - ``contactCountFetchedAt``
+     - datetime/null
+     - Timestamp when the Contact count was last fetched. Only included when ``withContactCounts`` is set in the request.
 
 
 **Event Properties**
@@ -246,6 +252,8 @@ List Campaigns
      - Only return currently published entities
    * - ``minimal``
      - Return only array of entities without additional lists in it
+   * - ``withContactCounts``
+     - Include ``contactCount`` and ``contactCountFetchedAt`` in the response for each Campaign. These values are cached for 12 hours by default.
 
 
 **Response**


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/dea43f1e-23de-4f62-aa45-0a4adf29e825)

Adds documentation for the new `withContactCounts` query parameter on the `GET /campaigns` endpoint. When provided, the API returns `contactCount` and `contactCountFetchedAt` fields for each Campaign. Also documents the 12-hour caching behavior for contact counts.

### Trigger Events

<details>
<summary><a href="https://github.com/mautic/mautic/pull/15878">mautic/mautic PR #15878: Add Contact count to Campaigns API object (#2884)</a></summary>
<br>

**Promptless Research** (1 GitHub PR)

- [Reviewed mautic/mautic#15878](https://github.com/mautic/mautic/pull/15878)

**Agent Response**

> I've completed the documentation update for PR #15878. Here's a summary:
> 
> ## Summary
> 
> I created a documentation suggestion that updates the Campaigns API documentation to cover the new `withContactCounts` query parameter.
> 
> ### Changes Made to `docs/rest_api/campaigns.rst`:
> 
> 1. **Added `withContactCounts` to the Query Parameters table** in the List Campaigns section, with a description explaining that it includes contact count fields and notes the 12-hour caching behavior.
> 
> 2. **Added two new properties to the Campaign Properties table**:
>    - `contactCount` (int) - Number of Contacts in the Campaign
>    - `contactCountFetchedAt` (datetime/null) - Timestamp when the Contact count was last fetched
> 
> Both new properties are documented as only being included when `withContactCounts` is set in the request.
> 
> ### Documentation Suggestion
> 
> **Title**: Document withContactCounts parameter for Campaigns API
> 
> **URL**: https://app.gopromptless.ai/suggestions/dea43f1e-23de-4f62-aa45-0a4adf29e825
> 
> This PR adds a useful feature for API consumers who need to know how many contacts are in each campaign without making additional API calls. The documentation captures both the functionality and the caching behavior (12-hour TTL) that developers should be aware of when using this parameter.

</details>



---

_Tip: Leave inline comments with `@Promptless` on suggestion diffs in the [Promptless dashboard](https://app.gopromptless.ai/suggestions) for targeted refinements 💬_