### PR TITLE
[DOCS]: Add "Cookie helper" page

### DIFF
--- a/docs/plugin_services/cookie_helper.rst
+++ b/docs/plugin_services/cookie_helper.rst
@@ -1,7 +1,7 @@
 Cookie helper
 #############
 
-The Cookie helper lets plugins read request cookies and queue response cookies while reusing Mautic cookie defaults (path, domain, secure, and HTTP-only).
+The Cookie helper lets Plugins read request cookies and queue response cookies while reusing Mautic cookie defaults - path, domain, secure, and HTTP-only.
 
 Using the helper
 ****************
@@ -38,12 +38,12 @@ Cookie methods
 
 The helper exposes these main methods:
 
-- ``getCookie(string $key, $default = null)``: reads a cookie from the current request.
-- ``setCookie(string $name, $value, ?int $expire = 1800, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = Cookie::SAMESITE_LAX)``: queues a cookie on the response.
-- ``deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = Cookie::SAMESITE_LAX)``: expires a cookie.
+* ``getCookie(string $key, $default = null)``: reads a cookie from the current request.
+* ``setCookie(string $name, $value, ?int $expire = 1800, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = Cookie::SAMESITE_LAX)``: queues a cookie on the response.
+* ``deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = Cookie::SAMESITE_LAX)``: expires a cookie.
 
-If optional arguments are omitted in ``setCookie()`` and ``deleteCookie()``, Mautic uses configured defaults.
+If you omit optional arguments in ``setCookie()`` and ``deleteCookie()``, Mautic uses configured defaults.
 
 .. tip::
 
-   Use ``Cookie::SAMESITE_STRICT`` or ``Cookie::SAMESITE_NONE`` when your plugin requires explicit SameSite behavior.
+   Use ``Cookie::SAMESITE_STRICT`` or ``Cookie::SAMESITE_NONE`` when your Plugin requires explicit SameSite behavior.

--- a/docs/plugin_services/cookie_helper.rst
+++ b/docs/plugin_services/cookie_helper.rst
@@ -1,14 +1,49 @@
 Cookie helper
 #############
 
-.. vale off
+The Cookie helper lets plugins read request cookies and queue response cookies while reusing Mautic cookie defaults (path, domain, secure, and HTTP-only).
 
-.. note::
+Using the helper
+****************
 
-   The content for this page requires a major update. The legacy page contains outdated and potentially inaccurate information. You can still access it in the :xref:`legacy repository`.
+Inject ``Mautic\CoreBundle\Helper\CookieHelper`` into your service, or retrieve it from the container in legacy code.
 
-   If you're interested in helping develop the new content for this page and others, consider joining the documentation efforts.
+.. code-block:: php
 
-   Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
+   <?php
 
-.. vale on
+   use Mautic\CoreBundle\Helper\CookieHelper;
+
+   final class ExampleService
+   {
+       public function __construct(private CookieHelper $cookieHelper)
+       {
+       }
+
+       public function handleCookie(): void
+       {
+           // Set a cookie that expires in 1 hour (3600 seconds)
+           $this->cookieHelper->setCookie('example_cookie', 'example_value', 3600);
+
+           // Read a cookie value with fallback
+           $value = $this->cookieHelper->getCookie('example_cookie', 'default_value');
+
+           // Remove the cookie
+           $this->cookieHelper->deleteCookie('example_cookie');
+       }
+   }
+
+Cookie methods
+**************
+
+The helper exposes these main methods:
+
+- ``getCookie(string $key, $default = null)``: reads a cookie from the current request.
+- ``setCookie(string $name, $value, ?int $expire = 1800, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = Cookie::SAMESITE_LAX)``: queues a cookie on the response.
+- ``deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = Cookie::SAMESITE_LAX)``: expires a cookie.
+
+If optional arguments are omitted in ``setCookie()`` and ``deleteCookie()``, Mautic uses configured defaults.
+
+.. tip::
+
+   Use ``Cookie::SAMESITE_STRICT`` or ``Cookie::SAMESITE_NONE`` when your plugin requires explicit SameSite behavior.

--- a/docs/plugin_services/cookie_helper.rst
+++ b/docs/plugin_services/cookie_helper.rst
@@ -1,7 +1,11 @@
 Cookie helper
 #############
 
+.. vale off
+
 The Cookie helper lets Plugins read request cookies and queue response cookies while reusing Mautic cookie defaults - path, domain, secure, and HTTP-only.
+
+.. vale on
 
 Using the helper
 ****************


### PR DESCRIPTION
Closes #336

- replace the placeholder note with a real Cookie helper page
- migrate and modernize the legacy guidance
- keep scope limited to the target page