### PR TITLE
Fix: Link paths and toctree

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,7 +79,6 @@ There are several ways to support Mautic other than contributing with code.
    design/labelling
    design/notifications
    design/flash_messages
-   design/protip
    design/quick_filters
    design/retrieving_system_information
    design/utilities
@@ -144,7 +143,7 @@ There are several ways to support Mautic other than contributing with code.
    plugins/config
    plugins/event_listeners
    plugins/installation
-   plugins/data
+   plugins/database
    plugins/cache
    plugins/translations
    plugins/continuous_integration

--- a/docs/links/mautic_chart_helpers_folder_70.py
+++ b/docs/links/mautic_chart_helpers_folder_70.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Mautic CoreBundle Chart Helpers" 
 link_text = "Mautic CoreBundle Chart Helpers" 
-link_url = "https://github.com/mautic/mautic/tree/5.2/app/bundles/CoreBundle/Helper/Chart" 
+link_url = "https://github.com/mautic/mautic/tree/7.0/app/bundles/CoreBundle/Helper/Chart" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_docs_mtc_js.py
+++ b/docs/links/mautic_docs_mtc_js.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Mautic tracking script docs"
 link_text = "Mautic tracking script docs" 
-link_url = "https://docs.mautic.org/en/5.x/configuration/tracking_script.html"
+link_url = "https://docs.mautic.org/en/7.0/configuration/tracking_script.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_report_builder_70.py
+++ b/docs/links/mautic_report_builder_70.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "MauticReportBuilder" 
 link_text = "MauticReportBuilder" 
-link_url = "https://github.com/mautic/mautic/blob/5.2/app/bundles/ReportBundle/Builder/MauticReportBuilder.php" 
+link_url = "https://github.com/mautic/mautic/blob/7.0/app/bundles/ReportBundle/Builder/MauticReportBuilder.php" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_report_generator_event_70.py
+++ b/docs/links/mautic_report_generator_event_70.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Mautic ReportGeneratorEvent" 
 link_text = "Mautic ReportGeneratorEvent" 
-link_url = "https://github.com/mautic/mautic/blob/5.2/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php" 
+link_url = "https://github.com/mautic/mautic/blob/7.0/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_rest_api_auth_docs.py
+++ b/docs/links/mautic_rest_api_auth_docs.py
@@ -1,7 +1,7 @@
 from . import link
 
 link_name = "Mautic REST API Authentication" 
-link_text = "REST API Authentication legacy page" 
-link_url = "https://github.com/mautic/developer-documentation/blob/main/source/includes/_api_authorization_basic.md" 
+link_text = "REST API Authentication" 
+link_url = "https://devdocs.mautic.org/en/7.0/rest_api/authentication.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_slack.py
+++ b/docs/links/mautic_slack.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Mautic Slack" 
 link_text = "Slack" 
-link_url = "https://mau.tc/slack-invite" 
+link_url = "https://mautic.org/slack" 
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
## Description

This PR fixes links and paths with below details:

- Removed `design/protip` from toctree as it's no longer available
- Renamed `plugins/data` to `plugins/database` at toctree
- Fixed broken link to Mautic Slack
- Renamed files and link paths to Mautic 7.0

<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

N/A


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->