### PR TITLE
docs: Add Tweets API endpoint documentation (verified against 7.0)

### DIFF
--- a/docs/rest_api/tweets.rst
+++ b/docs/rest_api/tweets.rst
@@ -5,7 +5,7 @@ Use this endpoint to obtain details on Mautic's Tweets. Implemented in Mautic 2.
 
 .. note::
 
-   The Tweets feature is part of the MauticSocialBundle plugin. Twitter integration must be enabled for this API to work.
+   The Tweets feature is part of the **Mautic Bundle for Social** Plugin. Integration with Twitter must be active for this API to work.
 
 Using the Mautic API library
 ****************************
@@ -200,6 +200,8 @@ HTTP request
 Query parameters
 ----------------
 
+.. vale off
+
 .. list-table::
    :widths: 20 20 60
    :header-rows: 1
@@ -230,6 +232,8 @@ Query parameters
    * - ``minimal``
      - boolean
      - Returns only a simple mapped object of entities without additional lists in it
+
+.. vale on
 
 Response
 ========

--- a/docs/rest_api/tweets.rst
+++ b/docs/rest_api/tweets.rst
@@ -1,7 +1,7 @@
 Tweets
 ######
 
-Use this endpoint to obtain details on Mautic's Tweets. Implemented in Mautic 2.8.0.
+Use this endpoint to obtain details on Mautic's Tweets.
 
 .. note::
 

--- a/docs/rest_api/tweets.rst
+++ b/docs/rest_api/tweets.rst
@@ -3,6 +3,10 @@ Tweets
 
 Use this endpoint to obtain details on Mautic's Tweets. Implemented in Mautic 2.8.0.
 
+.. note::
+
+   The Tweets feature is part of the MauticSocialBundle plugin. Twitter integration must be enabled for this API to work.
+
 Using the Mautic API library
 ****************************
 
@@ -71,6 +75,7 @@ Response
            "id": 1,
            "name": "Thank you tweet",
            "text": "Hi {twitter_handle}\n\nThanks for ...",
+           "description": "Used in the Product A campaign 1",
            "language": "en",
            "category": {
                "createdByUser": "John Doe",
@@ -82,13 +87,11 @@ Response
                "color": "244bc9",
                "bundle": "global"
            },
-           "tweetId": null,
            "mediaId": null,
            "mediaPath": null,
            "sentCount": 3,
            "favoriteCount": 0,
-           "retweetCount": 0,
-           "description": "Used in the Product A campaign 1"
+           "retweetCount": 0
        }
    }
 
@@ -114,7 +117,10 @@ Tweet properties
      - Title of the Tweet
    * - ``text``
      - string
-     - Message content of the Tweet
+     - Message content of the Tweet. Maximum 280 characters.
+   * - ``description``
+     - string
+     - Internal description for the Tweet
    * - ``isPublished``
      - boolean
      - Tweet publication status
@@ -148,6 +154,21 @@ Tweet properties
    * - ``category``
      - object
      - The Category for the Tweet
+   * - ``mediaId``
+     - string
+     - ID of the Twitter media object attached to the Tweet
+   * - ``mediaPath``
+     - string
+     - Path to the local media file
+   * - ``sentCount``
+     - integer
+     - Number of times this Tweet has been sent
+   * - ``favoriteCount``
+     - integer
+     - Number of favorites or likes on the Tweet
+   * - ``retweetCount``
+     - integer
+     - Number of retweets
 
 .. vale on
 
@@ -231,14 +252,14 @@ Response
                "id": 1,
                "name": "Thank you tweet",
                "text": "Hi {twitter_handle}\n\nThanks for ...",
+               "description": "Used in the Product A campaign 1",
                "language": "en",
                "category": null,
-               "tweetId": null,
                "mediaId": null,
                "mediaPath": null,
+               "sentCount": 3,
                "favoriteCount": 0,
-               "retweetCount": 0,
-               "description": "Used in the Product A campaign 1"
+               "retweetCount": 0
            }
        ]
    }
@@ -309,10 +330,13 @@ POST parameters
      - Description
    * - ``name``
      - string
-     - Title of the Tweet
+     - Title of the Tweet. Required.
    * - ``text``
      - string
-     - Message content of the Tweet
+     - Message content of the Tweet. Maximum 280 characters. Required.
+   * - ``description``
+     - string
+     - Internal description for the Tweet
    * - ``isPublished``
      - boolean
      - Tweet publication status
@@ -325,6 +349,15 @@ POST parameters
    * - ``language``
      - string
      - The language code for the Tweet, such as ``en``, ``fr``, and so on
+   * - ``category``
+     - integer
+     - ID of the Category for the Tweet
+   * - ``asset``
+     - integer
+     - ID of an Asset to link to the Tweet
+   * - ``page``
+     - integer
+     - ID of a Page to link to the Tweet
 
 .. vale on
 

--- a/docs/rest_api/tweets.rst
+++ b/docs/rest_api/tweets.rst
@@ -298,10 +298,10 @@ Creates a new Tweet.
 
    <?php
 
-   $data = array(
+   $data = [
        'name' => 'Tweet A',
        'text' => 'This is my first tweet created via API.',
-   );
+   ];
 
    $tweet = $tweetApi->create($data);
 
@@ -392,10 +392,10 @@ This operation supports ``PUT`` or ``PATCH`` depending on the desired behavior:
    <?php
 
    $id   = 1;
-   $data = array(
+   $data = [
        'name' => 'Tweet A',
        'text' => 'This is my first tweet created via API.',
-   );
+   ];
 
    // Create a new Tweet if ID 1 isn't found
    $createIfNotFound = true;

--- a/docs/rest_api/tweets.rst
+++ b/docs/rest_api/tweets.rst
@@ -1,14 +1,434 @@
 Tweets
 ######
 
+Use this endpoint to obtain details on Mautic's Tweets. Implemented in Mautic 2.8.0.
+
+Using the Mautic API library
+****************************
+
 .. vale off
 
-.. note::
-
-  The content for this page requires a major update. The legacy page contains outdated and potentially inaccurate information. You can still access it in the :xref:`legacy repository`.
-
-  If you're interested in helping develop the new content for this page and others, consider joining the documentation efforts.
-
-  Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
+You can interact with this API using the :xref:`Mautic API Library` as below, or the various HTTP endpoints described in this document.
 
 .. vale on
+
+.. code-block:: php
+
+   <?php
+   use Mautic\MauticApi;
+   use Mautic\Auth\ApiAuth;
+
+   // ...
+   $initAuth = new ApiAuth();
+   $auth     = $initAuth->newAuth($settings);
+   $apiUrl   = "https://example.com";
+   $api      = new MauticApi();
+   $tweetApi = $api->newApi("tweets", $auth, $apiUrl);
+
+.. vale off
+
+Get Tweet
+*********
+
+.. vale on
+
+Retrieves an individual Tweet by ID.
+
+.. code-block:: php
+
+   <?php
+
+   //...
+   $tweet = $tweetApi->get($id);
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``GET /tweets/ID``
+
+Response
+========
+
+* Returns ``200 OK`` when the request successfully retrieves the Tweet.
+
+.. _get Tweet response:
+
+.. code-block:: json
+
+   {
+       "tweet": {
+           "isPublished": true,
+           "dateAdded": "2026-02-03T17:51:58+00:00",
+           "dateModified": "2026-03-28T11:03:03+00:00",
+           "createdBy": 1,
+           "createdByUser": "John Doe",
+           "modifiedBy": 1,
+           "modifiedByUser": "John Doe",
+           "id": 1,
+           "name": "Thank you tweet",
+           "text": "Hi {twitter_handle}\n\nThanks for ...",
+           "language": "en",
+           "category": {
+               "createdByUser": "John Doe",
+               "modifiedByUser": null,
+               "id": 185,
+               "title": "Thank you tweets",
+               "alias": "thank-you-tweets",
+               "description": null,
+               "color": "244bc9",
+               "bundle": "global"
+           },
+           "tweetId": null,
+           "mediaId": null,
+           "mediaPath": null,
+           "sentCount": 3,
+           "favoriteCount": 0,
+           "retweetCount": 0,
+           "description": "Used in the Product A campaign 1"
+       }
+   }
+
+.. _get Tweet properties:
+
+Tweet properties
+----------------
+
+.. vale off
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``id``
+     - integer
+     - ID of the Tweet
+   * - ``name``
+     - string
+     - Title of the Tweet
+   * - ``text``
+     - string
+     - Message content of the Tweet
+   * - ``isPublished``
+     - boolean
+     - Tweet publication status
+   * - ``publishUp``
+     - datetime
+     - Activation date and time for the Tweet
+   * - ``publishDown``
+     - datetime
+     - Deactivation date and time for the Tweet
+   * - ``dateAdded``
+     - datetime
+     - Tweet record creation date and time
+   * - ``createdBy``
+     - integer
+     - ID of the User who created the Tweet
+   * - ``createdByUser``
+     - string
+     - Name of the User who created the Tweet
+   * - ``dateModified``
+     - datetime
+     - Tweet record last modification date and time
+   * - ``modifiedBy``
+     - integer
+     - ID of the User who last modified the Tweet
+   * - ``modifiedByUser``
+     - string
+     - Name of the User who last modified the Tweet
+   * - ``language``
+     - string
+     - The language code for the Tweet, such as ``en``, ``fr``, and so on
+   * - ``category``
+     - object
+     - The Category for the Tweet
+
+.. vale on
+
+.. vale off
+
+List Tweets
+***********
+
+.. vale on
+
+Retrieves a list of Tweets.
+
+.. code-block:: php
+
+   <?php
+   // ...
+
+   $tweets = $tweetApi->getList($searchFilter, $start, $limit, $orderBy, $orderByDir, $publishedOnly, $minimal);
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``GET /tweets``
+
+Query parameters
+----------------
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``search``
+     - string
+     - String or search command to filter entities
+   * - ``start``
+     - integer
+     - Starting row for the returned entities - defaults to 0
+   * - ``limit``
+     - integer
+     - Maximum number of entities to return - defaults to 30
+   * - ``orderBy``
+     - string
+     - Column to sort by. Any column in the response is valid.
+
+       **Note**: convert ``camelCase`` properties to ``snake_case``. For example, ``dateAdded`` becomes ``date_added``, and so on
+   * - ``orderByDir``
+     - string
+     - Order direction - ``asc`` or ``desc``
+   * - ``publishedOnly``
+     - boolean
+     - Returns only currently published entities
+   * - ``minimal``
+     - boolean
+     - Returns only a simple mapped object of entities without additional lists in it
+
+Response
+========
+
+* Returns ``200 OK`` when the request successfully retrieves the Tweets list.
+
+.. code-block:: json
+
+   {
+       "total": 1,
+       "tweets": [
+           {
+               "isPublished": true,
+               "dateAdded": "2026-02-03T17:51:58+00:00",
+               "dateModified": "2026-03-28T11:03:03+00:00",
+               "createdBy": 1,
+               "createdByUser": "John Doe",
+               "modifiedBy": 1,
+               "modifiedByUser": "John Doe",
+               "id": 1,
+               "name": "Thank you tweet",
+               "text": "Hi {twitter_handle}\n\nThanks for ...",
+               "language": "en",
+               "category": null,
+               "tweetId": null,
+               "mediaId": null,
+               "mediaPath": null,
+               "favoriteCount": 0,
+               "retweetCount": 0,
+               "description": "Used in the Product A campaign 1"
+           }
+       ]
+   }
+
+Properties
+----------
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``total``
+     - integer
+     - Total count of Tweets
+   * - ``tweets``
+     - array
+     - An array of Tweet objects
+
+.. vale off
+
+For the rest of the properties, refer to :ref:`Tweet properties <get Tweet properties>`.
+
+.. vale off
+
+Create Tweet
+************
+
+.. vale on
+
+Creates a new Tweet.
+
+.. code-block:: php
+
+   <?php
+
+   $data = array(
+       'name' => 'Tweet A',
+       'text' => 'This is my first tweet created via API.',
+   );
+
+   $tweet = $tweetApi->create($data);
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``POST /tweets/new``
+
+.. _create Tweet POST parameters:
+
+POST parameters
+---------------
+
+.. vale off
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``name``
+     - string
+     - Title of the Tweet
+   * - ``text``
+     - string
+     - Message content of the Tweet
+   * - ``isPublished``
+     - boolean
+     - Tweet publication status
+   * - ``publishUp``
+     - datetime
+     - Activation date and time for the Tweet
+   * - ``publishDown``
+     - datetime
+     - Deactivation date and time for the Tweet
+   * - ``language``
+     - string
+     - The language code for the Tweet, such as ``en``, ``fr``, and so on
+
+.. vale on
+
+Response
+========
+
+* Returns ``201 Created`` when the request successfully creates a Tweet.
+
+The response is a JSON object similar to :ref:`Get Tweet <get Tweet response>`.
+
+Properties
+----------
+
+Refer to :ref:`Tweet properties <get Tweet properties>`.
+
+.. vale off
+
+Edit Tweet
+**********
+
+.. vale on
+
+Edits a Tweet.
+
+This operation supports ``PUT`` or ``PATCH`` depending on the desired behavior:
+
+* ``PUT``: **full replacement**. The request creates a new Tweet if the ID is missing. If the ID exists, the request clears all existing data and replaces it with the provided values.
+* ``PATCH``: **partial update**. The request only updates field values based on the request data. The request fails when the Tweet ID doesn't exist.
+
+.. code-block:: php
+
+   <?php
+
+   $id   = 1;
+   $data = array(
+       'name' => 'Tweet A',
+       'text' => 'This is my first tweet created via API.',
+   );
+
+   // Create a new Tweet if ID 1 isn't found
+   $createIfNotFound = true;
+
+   $tweet = $tweetApi->edit($id, $data, $createIfNotFound);
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+* ``PUT /tweets/ID/edit``: updates an existing Tweet or creates a new one when the ID doesn't exist.
+* ``PATCH /tweets/ID/edit``: updates an existing Tweet. The request fails when the ID doesn't exist.
+
+POST parameters
+---------------
+
+Accepts the same parameters as those described in :ref:`Create Tweet <create Tweet POST parameters>`. All parameters are optional.
+
+Response
+========
+
+* ``PUT``: returns ``200 OK`` when the request successfully updates the Tweet or ``201 Created`` when the request creates a Tweet.
+* ``PATCH``: returns ``200 OK`` when the request successfully updates the Tweet or ``404 Not Found`` error when the Tweet ID doesn't exist.
+
+The response is a JSON object similar to :ref:`Get Tweet <get Tweet response>`.
+
+Properties
+----------
+
+Refer to :ref:`Tweet properties <get Tweet properties>`.
+
+.. vale off
+
+Delete Tweet
+************
+
+.. vale on
+
+Deletes a Tweet.
+
+.. code-block:: php
+
+   <?php
+
+   $tweet = $tweetApi->delete($id);
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``DELETE /tweets/ID/delete``
+
+Response
+========
+
+* Returns ``200 OK`` when the request successfully deletes the Tweet.
+
+The response is a JSON object containing the data of the deleted Tweet, similar to :ref:`Get Tweet <get Tweet response>`.
+
+Properties
+----------
+
+Refer to :ref:`Tweet properties <get Tweet properties>`.


### PR DESCRIPTION
Migrates and converts the Tweets API documentation from the legacy repository to RST format. Verified against Mautic 7.0 source code: confirmed all 5 CRUD endpoints exist, added missing properties (description, mediaId, mediaPath, sentCount, favoriteCount, retweetCount), documented 280 character text limit, and removed non-existent tweetId field. Twitter integration must be enabled for the API to work.