### PR TITLE
Document LeadGetCurrentEvent for skipping last active logging

### DIFF
--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -181,9 +181,9 @@ Review the sample code on how to obtain the currently tracked Contact.
 Skipping last active logging
 ============================
 
-When Mautic tracks a Contact, it automatically updates the Contact's 'last active' timestamp. Sometimes you'll want to prevent this update - for example, when automated processes access pages or when tracking pixel loads shouldn't count as real user activity.
+When Mautic tracks a Contact, it automatically updates the Contact's 'last active' timestamp. Sometimes you want to prevent this update, for example, when automated processes access pages or when tracking pixel loads shouldn't count as real User activity.
 
-To skip the last active logging, subscribe to the ``LeadGetCurrentEvent`` and call ``skipContactLastActiveLogged()`` when your conditions are met.
+To skip the last active logging, subscribe to the ``LeadGetCurrentEvent`` and call ``skipContactLastActiveLogged()`` when your conditions apply.
 
 .. code-block:: PHP
 
@@ -231,13 +231,13 @@ The ``LeadGetCurrentEvent`` provides the following methods:
    * - ``getRequest()``
      - Returns the current HTTP request, or ``null`` if not available.
    * - ``getContact()``
-     - Returns the Contact that was set by a previous listener, or ``null``.
+     - Returns the Contact that a previous listener set, or ``null``.
    * - ``setContact(?Lead $contact)``
      - Sets the Contact to use for tracking.
    * - ``skipContactLastActiveLogged()``
-     - Prevents the Contact's 'last active' timestamp from being updated.
+     - Prevents Mautic from updating the Contact's 'last active' timestamp.
    * - ``isSkipContactLastActiveLogged()``
-     - Returns whether the last active logging should be skipped.
+     - Returns whether to skip the last active logging.
 
 Contact timeline/history
 ************************

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -181,7 +181,7 @@ Review the sample code on how to obtain the currently tracked Contact.
 Skipping last active logging
 ============================
 
-When Mautic tracks a Contact, it automatically updates the Contact's 'last active' timestamp. Sometimes you want to prevent this update, for example, when automated processes access pages or when tracking pixel loads shouldn't count as real User activity.
+When Mautic tracks a Contact, it automatically updates the Contact's 'last active' timestamp. You may want to prevent this update in several scenarios, such as when automated processes access pages or when you don't want tracking pixel loads to count as real User activity.
 
 To skip the last active logging, subscribe to the ``LeadGetCurrentEvent`` and call ``skipContactLastActiveLogged()`` when your conditions apply.
 

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -223,6 +223,8 @@ To skip the last active logging, subscribe to the ``LeadGetCurrentEvent`` and ca
 
 The ``LeadGetCurrentEvent`` provides the following methods:
 
+.. vale off
+
 .. list-table::
    :header-rows: 1
 
@@ -238,6 +240,8 @@ The ``LeadGetCurrentEvent`` provides the following methods:
      - Prevents Mautic from updating the Contact's 'last active' timestamp.
    * - ``isSkipContactLastActiveLogged()``
      - Returns whether to skip the last active logging.
+
+.. vale on
 
 Contact timeline/history
 ************************

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -178,12 +178,12 @@ Review the sample code on how to obtain the currently tracked Contact.
       }
   }
 
-Skipping last active logging
-============================
+Skipping 'last active' logging
+==============================
 
 When Mautic tracks a Contact, it automatically updates the Contact's 'last active' timestamp. You may want to prevent this update in several scenarios, such as when automated processes access pages or when you don't want tracking pixel loads to count as real User activity.
 
-To skip the last active logging, subscribe to the ``LeadGetCurrentEvent`` and call ``skipContactLastActiveLogged()`` when your conditions apply.
+To skip the 'last active' logging, subscribe to the ``LeadGetCurrentEvent`` and call ``skipContactLastActiveLogged()`` when your conditions apply.
 
 .. code-block:: PHP
 
@@ -239,7 +239,7 @@ The ``LeadGetCurrentEvent`` provides the following methods:
    * - ``skipContactLastActiveLogged()``
      - Prevents Mautic from updating the Contact's 'last active' timestamp.
    * - ``isSkipContactLastActiveLogged()``
-     - Returns whether to skip the last active logging.
+     - Returns whether to skip the 'last active' logging.
 
 .. vale on
 

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -178,6 +178,67 @@ Review the sample code on how to obtain the currently tracked Contact.
       }
   }
 
+Skipping last active logging
+============================
+
+When Mautic tracks a Contact, it automatically updates the Contact's 'last active' timestamp. Sometimes you'll want to prevent this update - for example, when automated processes access pages or when tracking pixel loads shouldn't count as real user activity.
+
+To skip the last active logging, subscribe to the ``LeadGetCurrentEvent`` and call ``skipContactLastActiveLogged()`` when your conditions are met.
+
+.. code-block:: PHP
+
+  <?php
+  // plugins/HelloWorldBundle/EventListener/ContactTrackingSubscriber.php
+
+  declare(strict_types=1);
+
+  namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+  use Mautic\LeadBundle\Event\LeadGetCurrentEvent;
+  use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+  final class ContactTrackingSubscriber implements EventSubscriberInterface
+  {
+      public static function getSubscribedEvents(): array
+      {
+          return [
+              LeadGetCurrentEvent::class => 'onLeadGetCurrent',
+          ];
+      }
+
+      public function onLeadGetCurrent(LeadGetCurrentEvent $event): void
+      {
+          $request = $event->getRequest();
+
+          if (null === $request) {
+              return;
+          }
+
+          // Skip last active logging for requests with a specific header
+          if ($request->headers->has('X-Automated-Request')) {
+              $event->skipContactLastActiveLogged();
+          }
+      }
+  }
+
+The ``LeadGetCurrentEvent`` provides the following methods:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Method
+     - Description
+   * - ``getRequest()``
+     - Returns the current HTTP request, or ``null`` if not available.
+   * - ``getContact()``
+     - Returns the Contact that was set by a previous listener, or ``null``.
+   * - ``setContact(?Lead $contact)``
+     - Sets the Contact to use for tracking.
+   * - ``skipContactLastActiveLogged()``
+     - Prevents the Contact's 'last active' timestamp from being updated.
+   * - ``isSkipContactLastActiveLogged()``
+     - Returns whether the last active logging should be skipped.
+
 Contact timeline/history
 ************************
 

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -181,7 +181,11 @@ Review the sample code on how to obtain the currently tracked Contact.
 Skipping 'last active' logging
 ==============================
 
+.. vale off
+
 When Mautic tracks a Contact, it automatically updates the Contact's 'last active' timestamp. You may want to prevent this update in several scenarios, such as when automated processes access pages or when you don't want tracking pixel loads to count as real User activity.
+
+.. vale on
 
 To skip the 'last active' logging, subscribe to the ``LeadGetCurrentEvent`` and call ``skipContactLastActiveLogged()`` when your conditions apply.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/975f3784-32ed-46a1-88a3-6769e6911f2f)

Adds documentation for the new skipContactLastActiveLogged() method in LeadGetCurrentEvent, enabling developers to prevent Contact last active timestamp updates during tracking.

**Trigger Events**
- [mautic/mautic PR #16080: Option to skip contact last active logging](https://github.com/mautic/mautic/pull/16080)

---

_Tip: Enable auto-create PR in your [Docs Collection](https://app.gopromptless.ai/doc-collections) to publish suggestions automatically 🤖_