### PR TITLE
Document prefix and suffix column properties for reports

### DIFF
--- a/docs/plugin_extensions/reports.rst
+++ b/docs/plugin_extensions/reports.rst
@@ -171,7 +171,9 @@ Each column array can include the following properties:
 Example: percentage column with suffix
 --------------------------------------
 
-When creating columns that display percentages or other formatted numbers, use ``formula`` with ``suffix`` to ensure the column sorts numerically rather than alphabetically:
+Columns that display percentages or other formatted numbers need special handling to sort correctly. If you embed the formatting symbol directly in the formula using ``CONCAT``, the column sorts alphabetically as text rather than numerically, producing incorrect ordering like ``1%``, ``27%``, ``3%`` instead of ``1%``, ``3%``, ``27%``.
+
+To keep the underlying value numeric for proper sorting while still displaying the formatted result, use ``formula`` to compute the numeric value and ``suffix`` (or ``prefix``) to add the display formatting:
 
 .. code-block:: php
 
@@ -182,8 +184,6 @@ When creating columns that display percentages or other formatted numbers, use `
         'formula' => 'ROUND((' . $prefix . 'read_count/' . $prefix . 'sent_count)*100)',
         'suffix'  => '%',
     ],
-
-Without the ``suffix`` property, you might use ``CONCAT`` in the formula to append the ``%`` symbol. However, this causes the column to sort as text, resulting in incorrect ordering such as ``1%``, ``27%``, ``3%`` instead of ``1%``, ``3%``, ``27%``.
 
 Filter definition
 =================

--- a/docs/plugin_extensions/reports.rst
+++ b/docs/plugin_extensions/reports.rst
@@ -173,7 +173,7 @@ Example: percentage column with suffix
 
 Columns that display percentages or other formatted numbers need special handling to sort correctly. If you embed the formatting symbol directly in the formula using ``CONCAT``, the column sorts alphabetically as text rather than numerically, producing incorrect ordering like ``1%``, ``27%``, ``3%`` instead of ``1%``, ``3%``, ``27%``.
 
-To keep the underlying value numeric for proper sorting while still displaying the formatted result, use ``formula`` to compute the numeric value and ``suffix`` (or ``prefix``) to add the display formatting:
+To keep the underlying value numeric for proper sorting while still displaying the formatted result, use ``formula`` to compute the numeric value and ``suffix`` or ``prefix`` to add the display formatting:
 
 .. code-block:: php
 

--- a/docs/plugin_extensions/reports.rst
+++ b/docs/plugin_extensions/reports.rst
@@ -161,6 +161,29 @@ Each column array can include the following properties:
     * - ``link``
       - string
       - Route name to convert the value into a hyperlink. Typically used with an entity's ID. The route must accept ``objectAction`` and ``objectId`` parameters.
+    * - ``prefix``
+      - string
+      - Text to prepend to the displayed value. For formula columns, this separates display formatting from the underlying numeric value, ensuring proper sorting. For example, ``'prefix' => '$'`` for currency.
+    * - ``suffix``
+      - string
+      - Text to append to the displayed value. For formula columns, this separates display formatting from the underlying numeric value, ensuring proper sorting. For example, ``'suffix' => '%'`` for percentages.
+
+Example: percentage column with suffix
+--------------------------------------
+
+When creating columns that display percentages or other formatted numbers, use ``formula`` with ``suffix`` to ensure the column sorts numerically rather than alphabetically:
+
+.. code-block:: php
+
+    'read_ratio' => [
+        'alias'   => 'read_ratio',
+        'label'   => 'mautic.report.read_ratio',
+        'type'    => 'string',
+        'formula' => 'ROUND((' . $prefix . 'read_count/' . $prefix . 'sent_count)*100)',
+        'suffix'  => '%',
+    ],
+
+Without the ``suffix`` property, you might use ``CONCAT`` in the formula to append the ``%`` symbol. However, this causes the column to sort as text, resulting in incorrect ordering such as ``1%``, ``27%``, ``3%`` instead of ``1%``, ``3%``, ``27%``.
 
 Filter definition
 =================


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/e1787f3c-c53b-4bf2-a063-f94f516cbeec)

Documents the prefix and suffix properties for report column definitions, which allow developers to add display formatting to formula-based columns while preserving numeric sorting. Includes a code example showing proper usage with percentage columns.

**Trigger Events**
- [mautic/mautic PR #16126: \[UXUI-256\] Fix report ratio sorting](https://github.com/mautic/mautic/pull/16126)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_