### PR TITLE
Document sendToDnc field and Send Email to Contact API behavior

### DIFF
--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -733,8 +733,12 @@ Do Not Contact behavior
 
 This endpoint respects the Email's ``sendToDnc`` setting:
 
+.. vale off
+
 * When ``sendToDnc`` is ``false`` - **default**: the endpoint skips Contacts with **Do Not Contact** status, and the send fails silently.
 * When ``sendToDnc`` is ``true``: the endpoint sends to Contacts with **Unsubscribed** or **Manual** Do Not Contact status, while still respecting **Bounced** status.
+
+.. vale on
 
 To send to Contacts regardless of their subscription status, set ``sendToDnc: true`` on the Email entity before calling this endpoint.
 

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -572,6 +572,10 @@ POST parameters
      - boolean
      - When ``true``, the Email sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status. Defaults to ``false``.
 
+       **Permission:** Requires the ``email:emails:sendtodnc`` permission to set this field via API. If the authenticated User lacks this permission, the API ignores the ``sendToDnc`` parameter.
+
+       **PUT behavior:** For PUT requests, this field defaults to ``false`` when not explicitly provided, preventing accidental enablement during full replacement operations.
+
 .. vale on
 
 Response

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -92,6 +92,7 @@ Response
           "publishUp": null,
           "publishDown": null,
           "publicPreview": false,
+          "sendToDnc": false,
           "readCount": 0,
           "sentCount": 0,
           "revision": 2,
@@ -264,6 +265,9 @@ Email properties
    * - ``grapesjsbuilder``
      - associative array
      - Associative array of Email builder configuration
+   * - ``sendToDnc``
+     - boolean
+     - When ``true``, the Email sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status. Defaults to ``false``.
 
 .. vale on
 
@@ -368,6 +372,7 @@ Response
               "publishUp": null,
               "publishDown": null,
               "publicPreview": false,
+              "sendToDnc": false,
               "readCount": 0,
               "sentCount": 0,
               "revision": 4,
@@ -563,6 +568,9 @@ POST parameters
    * - ``headers``
      - array
      - Array of custom headers
+   * - ``sendToDnc``
+     - boolean
+     - When ``true``, the Email sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status. Defaults to ``false``.
 
 .. vale on
 

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -267,7 +267,7 @@ Email properties
      - Associative array of Email builder configuration
    * - ``sendToDnc``
      - boolean
-     - When ``true``, the Email sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status. Defaults to ``false``.
+     - Do Not Contact send status - set to ``true`` to send the Email to Contacts with **Unsubscribed** or **Manual** status, while still respecting **Bounced** status. Defaults to ``false``.
 
 .. vale on
 
@@ -570,7 +570,7 @@ POST parameters
      - Array of custom headers
    * - ``sendToDnc``
      - boolean
-     - When ``true``, the Email sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status. Defaults to ``false``.
+     - Do Not Contact send status - set to ``true`` to send the Email to Contacts with **Unsubscribed** or **Manual** status, while still respecting **Bounced** status. Defaults to ``false``.
 
        **Permission:** Requires the ``email:emails:sendtodnc`` permission to set this field via API. If the authenticated User lacks this permission, the API ignores the ``sendToDnc`` parameter.
 
@@ -733,12 +733,8 @@ Do Not Contact behavior
 
 This endpoint respects the Email's ``sendToDnc`` setting:
 
-.. vale off
-
-* When ``sendToDnc`` is ``false`` - **default**: the endpoint skips Contacts with Do Not Contact status, and the send fails silently.
-* When ``sendToDnc`` is ``true``: the endpoint sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status.
-
-.. vale on
+* When ``sendToDnc`` is ``false`` - **default**: the endpoint skips Contacts with **Do Not Contact** status, and the send fails silently.
+* When ``sendToDnc`` is ``true``: the endpoint sends to Contacts with **Unsubscribed** or **Manual** Do Not Contact status, while still respecting **Bounced** status.
 
 To send to Contacts regardless of their subscription status, set ``sendToDnc: true`` on the Email entity before calling this endpoint.
 

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -724,6 +724,16 @@ HTTP request
 
 ``POST /emails/ID/contact/CONTACT_ID/send``
 
+Do Not Contact behavior
+-----------------------
+
+This endpoint respects the Email's ``sendToDnc`` setting:
+
+* When ``sendToDnc`` is ``false`` (default): the endpoint skips Contacts with Do Not Contact status, and the send fails silently.
+* When ``sendToDnc`` is ``true``: the endpoint sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status.
+
+To send to Contacts regardless of their subscription status, set ``sendToDnc: true`` on the Email entity before calling this endpoint.
+
 Parameters
 ----------
 

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -735,7 +735,7 @@ This endpoint respects the Email's ``sendToDnc`` setting:
 
 .. vale off
 
-* When ``sendToDnc`` is ``false`` - **default**: the endpoint skips Contacts with **Do Not Contact** status, and the send fails silently.
+* When ``sendToDnc`` is ``false`` - **default**: the endpoint skips Contacts with Do Not Contact status, and the send fails silently.
 * When ``sendToDnc`` is ``true``: the endpoint sends to Contacts with **Unsubscribed** or **Manual** Do Not Contact status, while still respecting **Bounced** status.
 
 .. vale on

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -574,7 +574,7 @@ POST parameters
 
        **Permission:** Requires the ``email:emails:sendtodnc`` permission to set this field via API. If the authenticated User lacks this permission, the API ignores the ``sendToDnc`` parameter.
 
-       **PUT behavior:** For PUT requests, this field defaults to ``false`` when not explicitly provided, preventing accidental enablement during full replacement operations.
+       **PUT behavior:** For ``PUT`` requests, this field defaults to ``false`` when not explicitly provided, preventing accidental enablement during full replacement operations.
 
 .. vale on
 

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -724,13 +724,21 @@ HTTP request
 
 ``POST /emails/ID/contact/CONTACT_ID/send``
 
+.. vale off
+
 Do Not Contact behavior
 -----------------------
 
+.. vale on
+
 This endpoint respects the Email's ``sendToDnc`` setting:
 
-* When ``sendToDnc`` is ``false`` (default): the endpoint skips Contacts with Do Not Contact status, and the send fails silently.
+.. vale off
+
+* When ``sendToDnc`` is ``false`` - **default**: the endpoint skips Contacts with Do Not Contact status, and the send fails silently.
 * When ``sendToDnc`` is ``true``: the endpoint sends to Contacts with UNSUBSCRIBED or MANUAL Do Not Contact status, while still respecting BOUNCED status.
+
+.. vale on
 
 To send to Contacts regardless of their subscription status, set ``sendToDnc: true`` on the Email entity before calling this endpoint.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/9175489a-b780-4360-80ad-c7b88adffba4)

Documents the new sendToDnc boolean field on the Email entity, including the email:emails:sendtodnc permission required to set this field via API, the PUT behavior defaulting to false, and how the Send Email to Contact endpoint now respects this setting for Do Not Contact handling instead of always treating API-sent emails as transactional.

**Trigger Events**
- [mautic/mautic PR #16039: WIP: Ignore hard bounce when send to unsubscribed is checked](https://github.com/mautic/mautic/pull/16039)
- [mautic/mautic PR #15995: Truly transactional emails v2](https://github.com/mautic/mautic/pull/15995)
- [mautic/mautic PR #15995: Truly transactional emails v2](https://github.com/mautic/mautic/pull/15995)

---

_Tip: Send Promptless a meeting transcript in Slack to generate doc updates 📝_