### PR TITLE
fix: Add opencollective to `linkcheck_ignore`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,9 @@ html_css_files = ['tablefix.css']
 # A little context on the reason for ignoring is greatly appreciated!
 linkcheck_ignore = [
    # github anchors cause failures, so do not check any github url with an anchor
-   r'^https://github.com/.*#.*'
+   r'^https://github.com/.*#.*',
+   # 403 client error from these domains
+   r"https://opencollective.com/mautic",
 ]
 
 # Ensure that autosectionlabel will produce unique names


### PR DESCRIPTION
## Description

This PR adds a 403 status https://opencollective.com/mautic to `linkcheck_ignore` list.


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->