### PR TITLE
Document theme template sandbox restrictions

### DIFF
--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -221,7 +221,7 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
 Template sandbox restrictions
 =============================
 
-Mautic renders user-uploaded Theme templates in a sandboxed Twig environment to prevent security vulnerabilities. This sandbox blocks certain functions and filters that could enable remote code execution or data leakage.
+Mautic renders User-uploaded Theme templates in a Twig sandbox environment to prevent security vulnerabilities. This sandbox blocks certain functions and filters that could enable remote code execution or data leakage.
 
 **Blocked functions**
 

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -218,6 +218,39 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
         </body>
     </html>
 
+Template sandbox restrictions
+=============================
+
+Mautic renders user-uploaded Theme templates in a sandboxed Twig environment to prevent security vulnerabilities. This sandbox blocks certain functions and filters that could enable remote code execution or data leakage.
+
+**Blocked functions**
+
+The following Twig functions aren't available in Theme templates:
+
+- ``configGetParameter`` - could expose database credentials and secret keys
+- ``getEntity`` - could extract arbitrary data from the database
+- ``getEntities`` - could extract arbitrary data from the database
+- ``source`` - could read arbitrary files from the server
+- ``ini_get`` - could expose PHP configuration
+- ``is_file`` - could probe the filesystem
+- ``get_class`` - could enable reflection attacks
+- ``method_exists`` - could enable reflection attacks
+- ``is_class`` - could enable reflection attacks
+- ``is_extension_loaded`` - could probe system configuration
+- ``is_function`` - could enable reflection attacks
+
+**Blocked filters**
+
+The following Twig filters aren't available in Theme templates because they accept PHP callable strings:
+
+- ``map``
+- ``reduce``
+- ``filter``
+
+If your Theme template uses any of these functions or filters, Mautic throws a ``SecurityNotAllowedFilterError`` or ``SecurityNotAllowedFunctionError`` exception. Use alternative approaches that don't require these restricted operations.
+
+All other Mautic and Plugin Twig functions remain available in Theme templates.
+
 Thumbnails
 ==========
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/0ccb9a12-014d-40cf-a3df-d113ddee3ee0)

Documents the Twig sandbox environment that restricts dangerous functions and filters in user-uploaded theme templates. Lists all blocked functions (configGetParameter, getEntity, getEntities, source, etc.) and filters (map, reduce, filter) to help theme developers understand security constraints.

**Trigger Events**
- [mautic/mautic PR #16173: 5.2.11 update](https://github.com/mautic/mautic/pull/16173)

---

_Tip: Attach PDFs in Slack messages to Promptless—it can even extract images from them 📎_