### PR TITLE
Document Company soft delete event

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -38,6 +38,7 @@ Contact Points
 Continuous Integration
 Contribution(s)
 CORS
+CRM
 cron
 Cron
 CTRL

--- a/docs/webhooks/events/company_post_save.rst
+++ b/docs/webhooks/events/company_post_save.rst
@@ -28,6 +28,8 @@ Event properties
       - string
       - Date/time the event occurred in ISO 8601 format.
 
+.. _Company properties at Company created updated event:
+
 Company properties
 ******************
 

--- a/docs/webhooks/events/company_post_save.rst
+++ b/docs/webhooks/events/company_post_save.rst
@@ -28,8 +28,6 @@ Event properties
       - string
       - Date/time the event occurred in ISO 8601 format.
 
-.. _Company properties at Company created updated event:
-
 Company properties
 ******************
 

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -1,7 +1,11 @@
 Company soft deleted event
 ##########################
 
+.. vale off
+
 Triggered when Mautic marks a Company as soft deleted. The soft delete mechanism marks the Company for deletion without immediately removing it from the database. Depending on the ``update_company_mapping_data_in_background`` configuration parameter, the permanent deletion and Contact cleanup either happens synchronously or through a CLI command.
+
+.. vale on
 
 .. _company_soft_deleted_event_type:
 
@@ -26,15 +30,15 @@ Event properties
       - ID of the soft-deleted Company
     * - ``company``
       - object
-      - :ref:`Company object<webhooks/events/company_post_save:Company properties>`.
+      - :ref:`Company properties at Company created updated event`
     * - ``timestamp``
       - string
-      - Date/time the event occurred in ISO 8601 format.
+      - Date/time the event occurred in ISO 8601 format
 
 Listening to the event
 **********************
 
-Developers can subscribe to this event to react when Companies are marked for deletion. For example, you might synchronize the deletion to an external CRM or trigger cleanup processes.
+Developers can subscribe to this event to react when Companies are marked for deletion. For example, you might synchronize the deletion to an external Customer Relationship Management (CRM) system or trigger cleanup processes.
 
 .. code-block:: php
 

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -30,7 +30,7 @@ Event properties
       - ID of the soft-deleted Company
     * - ``company``
       - object
-      - :ref:`Company properties at Company created updated event`
+      - See :ref:`Company properties at Company created updated event`
     * - ``timestamp``
       - string
       - Date/time the event occurred in ISO 8601 format

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -57,4 +57,4 @@ Developers can subscribe to this event to react when Mautic marks Companies for 
 .. seealso::
 
     * :doc:`company_post_delete` - Triggered after permanent deletion
-    * :doc:`company_post_save` - Triggered when Companies are created or updated
+    * :doc:`company_post_save` - Triggered when Mautic creates or updates a Company

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -19,27 +19,6 @@ Event instance
 
 ``\Mautic\LeadBundle\Event\CompanyEvent``
 
-.. _company_soft_deleted_event_properties:
-
-Event properties
-****************
-
-.. list-table::
-    :header-rows: 1
-
-    * - Key
-      - Type
-      - Description
-    * - ``id``
-      - int
-      - ID of the soft-deleted Company
-    * - ``company``
-      - object
-      - See :ref:`Company properties at Company created updated event`
-    * - ``timestamp``
-      - string
-      - Date/time the event occurred in ISO 8601 format
-
 Listening to the event
 **********************
 

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -7,8 +7,6 @@ Triggered when Mautic marks a Company as soft deleted. The soft delete mechanism
 
 .. vale on
 
-.. _company_soft_deleted_event_type:
-
 Event type
 **********
 

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -14,6 +14,11 @@ Event type
 
 ``mautic.company_soft_delete``
 
+Event instance
+**************
+
+``\Mautic\LeadBundle\Event\CompanyEvent``
+
 .. _company_soft_deleted_event_properties:
 
 Event properties

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -1,0 +1,74 @@
+Company soft deleted event
+##########################
+
+Triggered when Mautic marks a Company as soft deleted. The soft delete mechanism marks the Company for deletion without immediately removing it from the database. Depending on the ``update_company_mapping_data_in_background`` configuration parameter, the permanent deletion and Contact cleanup either happens synchronously or through a CLI command.
+
+.. _company_soft_deleted_event_type:
+
+Event type
+**********
+
+``mautic.company_soft_delete``
+
+.. _company_soft_deleted_event_properties:
+
+Event properties
+****************
+
+.. list-table::
+    :header-rows: 1
+
+    * - Key
+      - Type
+      - Description
+    * - ``id``
+      - int
+      - ID of the soft-deleted Company
+    * - ``company``
+      - object
+      - :ref:`Company object<webhooks/events/company_post_save:Company properties>`.
+    * - ``timestamp``
+      - string
+      - Date/time the event occurred in ISO 8601 format.
+
+Listening to the event
+**********************
+
+Developers can subscribe to this event to react when Companies are marked for deletion. For example, you might synchronize the deletion to an external CRM or trigger cleanup processes.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/CompanySubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\LeadBundle\Event\CompanyEvent;
+    use Mautic\LeadBundle\LeadEvents;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    final class CompanySubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                LeadEvents::COMPANY_SOFT_DELETE => ['onCompanySoftDelete', 0],
+            ];
+        }
+
+        public function onCompanySoftDelete(CompanyEvent $event): void
+        {
+            $company = $event->getCompany();
+            $companyId = $company->getId();
+
+            // Synchronize the deletion to external systems
+            // or trigger additional cleanup processes
+        }
+    }
+
+.. seealso::
+
+    * :doc:`company_post_delete` - Triggered after permanent deletion
+    * :doc:`company_post_save` - Triggered when Companies are created or updated

--- a/docs/webhooks/events/company_soft_delete.rst
+++ b/docs/webhooks/events/company_soft_delete.rst
@@ -38,7 +38,7 @@ Event properties
 Listening to the event
 **********************
 
-Developers can subscribe to this event to react when Companies are marked for deletion. For example, you might synchronize the deletion to an external Customer Relationship Management (CRM) system or trigger cleanup processes.
+Developers can subscribe to this event to react when Mautic marks Companies for deletion. For example, you might synchronize the deletion to an external Customer Relationship Management - CRM - system or trigger cleanup processes.
 
 .. code-block:: php
 

--- a/docs/webhooks/events/index.rst
+++ b/docs/webhooks/events/index.rst
@@ -28,6 +28,7 @@ Below is a list of documented events with their event types and the structure of
    lead_channel_subscription_changed
    lead_company_change
    company_post_save
+   company_soft_delete
    company_post_delete
    email_on_send
    email_on_open


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/4e6571e0-4331-48fe-923b-4b5732058a55)

Add documentation for the new COMPANY_SOFT_DELETE event (mautic.company_soft_delete) that is dispatched when a Company is marked as soft deleted. Includes event type, properties, and a code example for subscribing to the event.

**Trigger Events**
- [mautic/mautic PR #16176: Handling relations between contacts and companies improved](https://github.com/mautic/mautic/pull/16176)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_