### PR TITLE
Document Campaign membership change lifecycle event

### DIFF
--- a/docs/plugin_extensions/campaigns.rst
+++ b/docs/plugin_extensions/campaigns.rst
@@ -1049,3 +1049,57 @@ Request body
 *   **If sending a ZIP file:** upload the ZIP file using form-data.
 
 .. vale on
+
+.. vale off
+
+Campaign lifecycle events
+*************************
+
+.. vale on
+
+Mautic dispatches lifecycle events at various points during Campaign processing. Plugins can subscribe to these events to extend Campaign functionality.
+
+Membership change event
+=======================
+
+The ``CampaignEvents::ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP`` event fires after a Campaign action modifies a Contact's Campaign membership. This occurs when a Campaign action adds or removes a Contact from another Campaign.
+
+Listeners receive a ``Mautic\CampaignBundle\Event\CampaignEvent`` object containing the Campaign that was modified.
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\CampaignBundle\CampaignEvents;
+    use Mautic\CampaignBundle\Event\CampaignEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class CampaignMembershipSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                CampaignEvents::ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP => ['onMembershipChange', 0],
+            ];
+        }
+
+        public function onMembershipChange(CampaignEvent $event): void
+        {
+            $campaign = $event->getCampaign();
+
+            // Perform custom logic when a Contact's Campaign membership changes
+        }
+    }
+
+.. php:class:: Mautic\CampaignBundle\Event\CampaignEvent
+
+    .. php:method:: public getCampaign()
+
+        Returns the Campaign entity that was modified.
+
+        :return: The Campaign whose membership changed.
+        :returntype: \\Mautic\\CampaignBundle\\Entity\\Campaign

--- a/docs/plugin_extensions/campaigns.rst
+++ b/docs/plugin_extensions/campaigns.rst
@@ -1057,14 +1057,14 @@ Campaign lifecycle events
 
 .. vale on
 
-Mautic dispatches lifecycle events at various points during Campaign processing. Plugins can subscribe to these events to extend Campaign functionality.
+Mautic dispatches lifecycle events at various Points during Campaign processing. Plugins can subscribe to these events to extend Campaign capability.
 
 Membership change event
 =======================
 
 The ``CampaignEvents::ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP`` event fires after a Campaign action modifies a Contact's Campaign membership. This occurs when a Campaign action adds or removes a Contact from another Campaign.
 
-Listeners receive a ``Mautic\CampaignBundle\Event\CampaignEvent`` object containing the Campaign that was modified.
+Listeners receive a ``Mautic\CampaignBundle\Event\CampaignEvent`` object containing the modified Campaign.
 
 .. code-block:: php
 
@@ -1099,7 +1099,7 @@ Listeners receive a ``Mautic\CampaignBundle\Event\CampaignEvent`` object contain
 
     .. php:method:: public getCampaign()
 
-        Returns the Campaign entity that was modified.
+        Returns the modified Campaign entity.
 
         :return: The Campaign whose membership changed.
         :returntype: \\Mautic\\CampaignBundle\\Entity\\Campaign


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/57e62365-e3fa-4f3f-a85c-2618fb547c01)

Documents the new ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP event added in mautic/mautic#16172. This event allows plugins to hook into Campaign membership changes when a Campaign action adds or removes a Contact from another Campaign.

**Trigger Events**
- [mautic/mautic PR #16172: Adding new ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP event](https://github.com/mautic/mautic/pull/16172)

---

_Tip: Use Slack message actions (⋯ menu → Update Docs) to capture doc updates without interrupting conversations 💬_