### PR TITLE
Document preview PDF generation events for Emails and Landing Pages

### DIFF
--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -506,12 +506,16 @@ Email stat helpers
 
 This section is in progress. See  ``\Mautic\EmailBundle\Stats\Helper\StatHelperInterface``
 
+.. vale off
+
 Preview PDF generation
 ----------------------
 
-Users can download Email previews as PDF files. Mautic uses an event-driven PDF generation process, enabling plugins and distributions to provide custom PDF renderers.
+.. vale on
 
-Mautic dispatches the ``\Mautic\EmailBundle\EmailEvents::EMAIL_PREVIEW_GENERATE_PDF`` event when a user downloads an Email preview as a PDF. The default community implementation uses Dompdf when available, falling back to a basic stdlib-based PDF generator.
+Users can download Email previews as PDF files. Mautic uses an event-driven PDF generation process, enabling Plugins and distributions to provide custom PDF generators.
+
+Mautic dispatches the ``\Mautic\EmailBundle\EmailEvents::EMAIL_PREVIEW_GENERATE_PDF`` event when a User downloads an Email preview as a PDF. The default community implementation uses Dompdf when available, falling back to a basic stdlib-based PDF generator.
 
 Event details
 =============
@@ -550,7 +554,7 @@ The event provides access to:
 * ``getHtmlContent()`` - The rendered HTML preview content
 * ``getEmail()`` - The Email entity
 * ``getContact()`` - The Contact context, if selected for preview
-* ``getRequest()`` - The HTTP Request object
+* ``getRequest()`` - The HTTP request object
 * ``getFileName()`` - The suggested PDF filename
 
 Event methods
@@ -558,13 +562,17 @@ Event methods
 
 To provide a custom PDF:
 
-1. Generate binary PDF bytes from the HTML content using ``getHtmlContent()``
-2. Call ``setPdfContent($bytes)`` to set the PDF content
-3. Optionally call ``setFileName()`` to customize the output filename
-4. Use ``hasPdfContent()`` to check if another subscriber already provided PDF content
+#. Generate binary PDF bytes from the HTML content using ``getHtmlContent()``
+#. Call ``setPdfContent($bytes)`` to set the PDF content
+#. Optionally call ``setFileName()`` to customize the output filename
+#. Use ``hasPdfContent()`` to verify if another subscriber already provided PDF content
+
+.. vale off
 
 Custom PDF generator example
 ============================
+
+.. vale on
 
 This example shows how to create a custom PDF generator using a hypothetical premium PDF service:
 

--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -506,6 +506,89 @@ Email stat helpers
 
 This section is in progress. See  ``\Mautic\EmailBundle\Stats\Helper\StatHelperInterface``
 
+Preview PDF generation
+----------------------
+
+Users can download Email previews as PDF files. Mautic uses an event-driven PDF generation process, enabling plugins and distributions to provide custom PDF renderers.
+
+Mautic dispatches the ``\Mautic\EmailBundle\EmailEvents::EMAIL_PREVIEW_GENERATE_PDF`` event when a user downloads an Email preview as a PDF. The default community implementation uses Dompdf when available, falling back to a basic stdlib-based PDF generator.
+
+Event details
+=============
+
+* **Event name:** ``mautic.email_preview_generate_pdf``
+* **Constant:** ``\Mautic\EmailBundle\EmailEvents::EMAIL_PREVIEW_GENERATE_PDF``
+* **Event class:** ``\Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent``
+
+Event payload
+=============
+
+The event provides access to:
+
+* ``getHtmlContent()`` - The rendered HTML preview content
+* ``getEmail()`` - The Email entity
+* ``getContact()`` - The Contact context, if selected for preview
+* ``getRequest()`` - The HTTP Request object
+* ``getFileName()`` - The suggested PDF filename
+
+Event methods
+=============
+
+To provide a custom PDF:
+
+1. Generate binary PDF bytes from the HTML content using ``getHtmlContent()``
+2. Call ``setPdfContent($bytes)`` to set the PDF content
+3. Optionally call ``setFileName()`` to customize the output filename
+4. Use ``hasPdfContent()`` to check if another subscriber already provided PDF content
+
+Custom PDF generator example
+============================
+
+This example shows how to create a custom PDF generator using a hypothetical premium PDF service:
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/EmailPdfSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\EmailBundle\EmailEvents;
+    use Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent;
+    use MauticPlugin\HelloWorldBundle\Service\PremiumPdfService;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    final class EmailPdfSubscriber implements EventSubscriberInterface
+    {
+        public function __construct(
+            private PremiumPdfService $pdfService,
+        ) {
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                EmailEvents::EMAIL_PREVIEW_GENERATE_PDF => ['onEmailPreviewGeneratePdf', 0],
+            ];
+        }
+
+        public function onEmailPreviewGeneratePdf(EmailPreviewPdfGenerationEvent $event): void
+        {
+            if ($event->hasPdfContent()) {
+                return;
+            }
+
+            $pdfBytes = $this->pdfService->htmlToPdf($event->getHtmlContent());
+            $event->setPdfContent($pdfBytes);
+        }
+    }
+
+.. note::
+
+   The default community subscriber runs at priority ``-255``. Register your subscriber at a higher priority, such as ``0``, to override the default PDF generation
+
 .. vale off
 
 Testing Email transports

--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -520,6 +520,28 @@ Event details
 * **Constant:** ``\Mautic\EmailBundle\EmailEvents::EMAIL_PREVIEW_GENERATE_PDF``
 * **Event class:** ``\Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent``
 
+Default implementation
+======================
+
+Mautic provides default PDF generation through:
+
+* **Subscriber:** ``\Mautic\EmailBundle\EventListener\EmailPreviewPdfSubscriber``
+* **Generator:** ``\Mautic\EmailBundle\Pdf\EmailPreviewPdfGenerator``
+
+The default subscriber runs at priority ``-255``, allowing custom implementations to take precedence.
+
+If no listener sets PDF content, the controller returns a 500 error.
+
+Routes
+======
+
+Email preview PDF downloads use these routes:
+
+* ``/email/preview/{objectId}/download/{downloadType}``
+* ``/email/preview/{objectId}/draft/download/{downloadType}``
+
+The ``downloadType`` parameter defaults to ``pdf``.
+
 Event payload
 =============
 
@@ -587,7 +609,7 @@ This example shows how to create a custom PDF generator using a hypothetical pre
 
 .. note::
 
-   The default community subscriber runs at priority ``-255``. Register your subscriber at a higher priority, such as ``0``, to override the default PDF generation
+   Register your subscriber at a higher priority, such as ``0`` or ``100``, to override the default PDF generation.
 
 .. vale off
 

--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -551,11 +551,15 @@ Event payload
 
 The event provides access to:
 
+.. vale off
+
 * ``getHtmlContent()`` - The rendered HTML preview content
 * ``getEmail()`` - The Email entity
 * ``getContact()`` - The Contact context, if selected for preview
 * ``getRequest()`` - The HTTP request object
 * ``getFileName()`` - The suggested PDF filename
+
+.. vale on
 
 Event methods
 =============

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -115,3 +115,86 @@ Below is an example of both Landing Page Tokens and Landing Page A/B Test Winner
             $event->setContent($content);
         }
     }
+
+Preview PDF generation
+**********************
+
+Users can download Landing Page previews as PDF files. Mautic uses an event-driven PDF generation process, enabling plugins and distributions to provide custom PDF renderers.
+
+Mautic dispatches the ``\Mautic\PageBundle\PageEvents::PAGE_PREVIEW_GENERATE_PDF`` event when a user downloads a Landing Page preview as a PDF. The default community implementation uses Dompdf when available, falling back to a basic stdlib-based PDF generator.
+
+Event details
+=============
+
+* **Event name:** ``mautic.page_preview_generate_pdf``
+* **Constant:** ``\Mautic\PageBundle\PageEvents::PAGE_PREVIEW_GENERATE_PDF``
+* **Event class:** ``\Mautic\PageBundle\Event\PagePreviewPdfGenerationEvent``
+
+Event payload
+=============
+
+The event provides access to:
+
+* ``getHtmlContent()`` - The rendered HTML preview content
+* ``getPage()`` - The Page entity
+* ``getContact()`` - The Contact context, if selected for preview
+* ``getRequest()`` - The HTTP Request object
+* ``getFileName()`` - The suggested PDF filename
+
+Event methods
+=============
+
+To provide a custom PDF:
+
+1. Generate binary PDF bytes from the HTML content using ``getHtmlContent()``
+2. Call ``setPdfContent($bytes)`` to set the PDF content
+3. Optionally call ``setFileName()`` to customize the output filename
+4. Use ``hasPdfContent()`` to check if another subscriber already provided PDF content
+
+Custom PDF generator example
+============================
+
+This example shows how to create a custom PDF generator using a hypothetical premium PDF service:
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/PagePdfSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\PageBundle\Event\PagePreviewPdfGenerationEvent;
+    use Mautic\PageBundle\PageEvents;
+    use MauticPlugin\HelloWorldBundle\Service\PremiumPdfService;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    final class PagePdfSubscriber implements EventSubscriberInterface
+    {
+        public function __construct(
+            private PremiumPdfService $pdfService,
+        ) {
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                PageEvents::PAGE_PREVIEW_GENERATE_PDF => ['onPagePreviewGeneratePdf', 0],
+            ];
+        }
+
+        public function onPagePreviewGeneratePdf(PagePreviewPdfGenerationEvent $event): void
+        {
+            if ($event->hasPdfContent()) {
+                return;
+            }
+
+            $pdfBytes = $this->pdfService->htmlToPdf($event->getHtmlContent());
+            $event->setPdfContent($pdfBytes);
+        }
+    }
+
+.. note::
+
+   The default community subscriber runs at priority ``-255``. Register your subscriber at a higher priority, such as ``0``, to override the default PDF generation.

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -161,11 +161,15 @@ Event payload
 
 The event provides access to:
 
+.. vale off
+
 * ``getHtmlContent()`` - The rendered HTML preview content
 * ``getPage()`` - The Landing Page entity
 * ``getContact()`` - The Contact context, if selected for preview
 * ``getRequest()`` - The HTTP request object
 * ``getFileName()`` - The suggested PDF filename
+
+.. vale on
 
 Event methods
 =============

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -130,6 +130,28 @@ Event details
 * **Constant:** ``\Mautic\PageBundle\PageEvents::PAGE_PREVIEW_GENERATE_PDF``
 * **Event class:** ``\Mautic\PageBundle\Event\PagePreviewPdfGenerationEvent``
 
+Default implementation
+======================
+
+Mautic provides default PDF generation through:
+
+* **Subscriber:** ``\Mautic\PageBundle\EventListener\PagePreviewPdfSubscriber``
+* **Generator:** ``\Mautic\PageBundle\Pdf\PagePreviewPdfGenerator``
+
+The default subscriber runs at priority ``-255``, allowing custom implementations to take precedence.
+
+If no listener sets PDF content, the controller returns a 500 error.
+
+Routes
+======
+
+Landing Page preview PDF downloads use these routes:
+
+* ``/page/preview/{id}/download/{downloadType}``
+* ``/page/preview/{id}/draft/download/{downloadType}``
+
+The ``downloadType`` parameter defaults to ``pdf``.
+
 Event payload
 =============
 
@@ -197,4 +219,4 @@ This example shows how to create a custom PDF generator using a hypothetical pre
 
 .. note::
 
-   The default community subscriber runs at priority ``-255``. Register your subscriber at a higher priority, such as ``0``, to override the default PDF generation.
+   Register your subscriber at a higher priority, such as ``0`` or ``100``, to override the default PDF generation.

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -162,7 +162,7 @@ Event payload
 The event provides access to:
 
 * ``getHtmlContent()`` - The rendered HTML preview content
-* ``getPage()`` - The page entity
+* ``getPage()`` - The Landing Page entity
 * ``getContact()`` - The Contact context, if selected for preview
 * ``getRequest()`` - The HTTP request object
 * ``getFileName()`` - The suggested PDF filename

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -116,12 +116,16 @@ Below is an example of both Landing Page Tokens and Landing Page A/B Test Winner
         }
     }
 
+.. vale off
+
 Preview PDF generation
 **********************
 
-Users can download Landing Page previews as PDF files. Mautic uses an event-driven PDF generation process, enabling plugins and distributions to provide custom PDF renderers.
+.. vale on
 
-Mautic dispatches the ``\Mautic\PageBundle\PageEvents::PAGE_PREVIEW_GENERATE_PDF`` event when a user downloads a Landing Page preview as a PDF. The default community implementation uses Dompdf when available, falling back to a basic stdlib-based PDF generator.
+Users can download Landing Page previews as PDF files. Mautic uses an event-driven PDF generation process, enabling Plugins and distributions to provide custom PDF generators.
+
+Mautic dispatches the ``\Mautic\PageBundle\PageEvents::PAGE_PREVIEW_GENERATE_PDF`` event when a User downloads a Landing Page preview as a PDF. The default community implementation uses Dompdf when available, falling back to a basic stdlib-based PDF generator.
 
 Event details
 =============
@@ -158,9 +162,9 @@ Event payload
 The event provides access to:
 
 * ``getHtmlContent()`` - The rendered HTML preview content
-* ``getPage()`` - The Page entity
+* ``getPage()`` - The page entity
 * ``getContact()`` - The Contact context, if selected for preview
-* ``getRequest()`` - The HTTP Request object
+* ``getRequest()`` - The HTTP request object
 * ``getFileName()`` - The suggested PDF filename
 
 Event methods
@@ -168,13 +172,17 @@ Event methods
 
 To provide a custom PDF:
 
-1. Generate binary PDF bytes from the HTML content using ``getHtmlContent()``
-2. Call ``setPdfContent($bytes)`` to set the PDF content
-3. Optionally call ``setFileName()`` to customize the output filename
-4. Use ``hasPdfContent()`` to check if another subscriber already provided PDF content
+#. Generate binary PDF bytes from the HTML content using ``getHtmlContent()``
+#. Call ``setPdfContent($bytes)`` to set the PDF content
+#. Optionally call ``setFileName()`` to customize the output filename
+#. Use ``hasPdfContent()`` to verify if another subscriber already provided PDF content
+
+.. vale off
 
 Custom PDF generator example
 ============================
+
+.. vale on
 
 This example shows how to create a custom PDF generator using a hypothetical premium PDF service:
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/c90b4a10-6dc8-427f-b1fb-5aabd0442442)

Adds developer documentation for the new event-driven PDF generation feature introduced in mautic/mautic#16187. Documents the EMAIL_PREVIEW_GENERATE_PDF and PAGE_PREVIEW_GENERATE_PDF events, including event payload, methods, and code examples showing how plugins can provide custom PDF renderers.

**Trigger Events**
- [mautic/mautic PR #16187: Implement email and page preview PDF downloads](https://github.com/mautic/mautic/pull/16187)

---

_Tip: Attach PDFs in Slack messages to Promptless—it can even extract images from them 📎_