### PR TITLE
Document UrlTokenReplaceEvent for URL token replacement

### DIFF
--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -83,6 +83,8 @@ Basic token replacement
 
 .. vale off
 
+.. _Email A/B testing:
+
 Email A/B testing
 *****************
 

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -115,3 +115,82 @@ Below is an example of both Landing Page Tokens and Landing Page A/B Test Winner
             $event->setContent($content);
         }
     }
+
+.. vale off
+
+URL Token Replacement
+*********************
+
+.. vale on
+
+When a Contact clicks a tracked link, Mautic's redirect handler can replace Contact field tokens in the target URL before redirecting. This allows personalized destination URLs based on Contact data.
+
+The ``Mautic\PageBundle\Event\UrlTokenReplaceEvent`` event dispatches during the redirect process. Use it to customize or extend URL token replacement logic. By default, Mautic's built-in subscriber handles standard Contact field tokens like ``{contactfield=email}`` or ``{contactfield=firstname}``.
+
+Use cases for this event include:
+
+- Adding custom token types beyond Contact fields
+- Transforming token values before URL insertion
+- Implementing conditional token replacement based on Email context
+- Logging or auditing token replacements
+
+The event provides:
+
+- ``getContent()`` - Returns the current URL string
+- ``setContent(string $url)`` - Sets the modified URL
+- ``getLead()`` - Returns the ``Mautic\LeadBundle\Entity\Lead`` Contact entity
+- ``getEmailId()`` - Returns the Email ID if the redirect originated from an Email click, or ``null`` otherwise
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/UrlTokenSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\LeadBundle\Helper\TokenHelper;
+    use Mautic\PageBundle\Event\UrlTokenReplaceEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    final class UrlTokenSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                UrlTokenReplaceEvent::class => ['onUrlTokenReplace', 0],
+            ];
+        }
+
+        public function onUrlTokenReplace(UrlTokenReplaceEvent $event): void
+        {
+            $url = $event->getContent();
+
+            // Check if URL contains tokens using the public regex
+            if (!preg_match(TokenHelper::REGEX, $url)) {
+                return;
+            }
+
+            $contact = $event->getLead();
+            $emailId = $event->getEmailId();
+
+            // Implement custom token replacement logic
+            // For example, replace a custom token with Contact data
+            if (str_contains($url, '{custom_token}')) {
+                $customValue = $this->getCustomValue($contact, $emailId);
+                $url = str_replace('{custom_token}', urlencode($customValue), $url);
+                $event->setContent($url);
+            }
+        }
+
+        private function getCustomValue($contact, ?int $emailId): string
+        {
+            // Your custom logic here
+            return 'custom_value';
+        }
+    }
+
+.. note::
+
+    The ``TokenHelper::REGEX`` constant provides the regular expression pattern for matching Contact field tokens. Use this to check whether a URL contains tokens before performing replacements.

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -129,17 +129,17 @@ The ``Mautic\PageBundle\Event\UrlTokenReplaceEvent`` event dispatches during the
 
 Use cases for this event include:
 
-- Adding custom token types beyond Contact fields
-- Transforming token values before URL insertion
-- Implementing conditional token replacement based on Email context
-- Logging or auditing token replacements
+* Adding custom token types beyond Contact fields
+* Transforming token values before URL insertion
+* Implementing conditional token replacement based on Email context
+* Logging or auditing token replacements
 
 The event provides:
 
-- ``getContent()`` - Returns the current URL string
-- ``setContent(string $url)`` - Sets the modified URL
-- ``getLead()`` - Returns the ``Mautic\LeadBundle\Entity\Lead`` Contact entity
-- ``getEmailId()`` - Returns the Email ID if the redirect originated from an Email click, or ``null`` otherwise
+* ``getContent()`` - Returns the current URL string
+* ``setContent(string $url)`` - Sets the modified URL
+* ``getLead()`` - Returns the ``Mautic\LeadBundle\Entity\Lead`` Contact entity
+* ``getEmailId()`` - Returns the Email ID if the redirect originated from an Email click, or ``null`` otherwise
 
 .. code-block:: php
 
@@ -193,4 +193,4 @@ The event provides:
 
 .. note::
 
-    The ``TokenHelper::REGEX`` constant provides the regular expression pattern for matching Contact field tokens. Use this to check whether a URL contains tokens before performing replacements.
+   The ``TokenHelper::REGEX`` constant provides the regular expression pattern for matching Contact field tokens. Use this to check whether a URL contains tokens before performing replacements.

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -21,7 +21,7 @@ Both leverage the ``\Mautic\PageBundle\PageEvents::PAGE_ON_BUILD`` event. Read m
 
 .. vale off
 
-Landing Page tokens
+Landing page tokens
 *******************
 
 .. vale on
@@ -30,7 +30,7 @@ Landing Page tokens get handled exactly the same as :ref:`Email tokens<component
 
 .. vale off
 
-Page A/B Test Winner Criteria
+Page A/B test winner criteria
 *****************************
 
 Custom Landing Page A/B test winner criteria get handled exactly the same as :ref:`Email A/B test winner criteria<components/emails:Email tokens and A/B testing>` with the only differences being that the ``callback`` function gets passed ``Mautic\PageBundle\Entity\Page $page`` and ``Mautic\PageBundle\Entity\Page $parent`` instead.
@@ -118,7 +118,7 @@ Below is an example of both Landing Page Tokens and Landing Page A/B Test Winner
 
 .. vale off
 
-URL Token Replacement
+URL token replacement
 *********************
 
 .. vale on

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -34,7 +34,7 @@ Landing Page tokens get handled exactly the same as :ref:`Email tokens<component
 Page A/B test winner criteria
 *****************************
 
-Custom Landing Page A/B test winner criteria get handled exactly the same as :ref:`Email A/B testing`, except the callback function receives the following arguments:
+Custom Landing Page A/B test winner criteria get handled exactly the same as :ref:`Email A/B testing`, except the ``callback`` function receives the following arguments:
 
 * ``Mautic\PageBundle\Entity\Page $page``
 * ``Mautic\PageBundle\Entity\Page $parent``

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -1,4 +1,4 @@
-Landing pages
+Landing Pages
 #############
 
 .. vale off
@@ -14,14 +14,15 @@ Landing pages
 .. vale on
 
 There are two way to extend Landing Pages:
-- Landing Page tokens used to insert Dynamic Content into a Landing Page
-- A/B test winning criteria
+
+* Landing Page tokens used to insert Dynamic Content into a Landing Page
+* A/B test winning criteria
 
 Both leverage the ``\Mautic\PageBundle\PageEvents::PAGE_ON_BUILD`` event. Read more about :ref:`plugins/event_listeners:Event listeners`.
 
 .. vale off
 
-Landing page tokens
+Landing Page tokens
 *******************
 
 .. vale on

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -13,7 +13,7 @@ Landing Pages
 
 .. vale on
 
-There are two way to extend Landing Pages:
+There are two ways to extend Landing Pages:
 
 * Landing Page tokens used to insert Dynamic Content into a Landing Page
 * A/B test winning criteria
@@ -34,7 +34,11 @@ Landing Page tokens get handled exactly the same as :ref:`Email tokens<component
 Page A/B test winner criteria
 *****************************
 
-Custom Landing Page A/B test winner criteria get handled exactly the same as :ref:`Email A/B test winner criteria<components/emails:Email tokens and A/B testing>` with the only differences being that the ``callback`` function gets passed ``Mautic\PageBundle\Entity\Page $page`` and ``Mautic\PageBundle\Entity\Page $parent`` instead.
+Custom Landing Page A/B test winner criteria get handled exactly the same as :ref:`Email A/B testing`, except the callback function receives the following arguments:
+
+* ``Mautic\PageBundle\Entity\Page $page``
+* ``Mautic\PageBundle\Entity\Page $parent``
+
 ``$children`` is an ArrayCollection of Page entities as well.
 
 .. vale on


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/95fbbf92-731e-4721-a929-cf54e781f715)

Documents the new UrlTokenReplaceEvent extension point introduced in mautic/mautic#16199. Includes explanation of the event's purpose, available methods, and a complete code example showing how to implement custom URL token replacement in a Plugin.

**Trigger Events**
- [mautic/mautic PR #16199: Replace tokens in URLs via UrlTokenReplaceEvent](https://github.com/mautic/mautic/pull/16199)

---

_Tip: Enable auto-create PR in your [Docs Collection](https://app.gopromptless.ai/doc-collections) to review suggestions directly in GitHub 🤖_