### PR TITLE
docs: Document theme template sandbox restrictions

### DIFF
--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -221,7 +221,7 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
 Template sandbox restrictions
 =============================
 
-Mautic renders user-uploaded Theme templates in a restricted Twig sandbox environment. Certain functions and filters that could enable remote code execution, data leakage, or filesystem probing are blocked.
+Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment. The sandbox blocks certain functions and filters that could enable remote code execution, data leakage, or filesystem probing.
 
 If your Theme template uses a restricted function or filter, Mautic throws an exception such as ``SecurityNotAllowedFilterError`` or ``SecurityNotAllowedFunctionError``. Use alternative approaches that don't require the restricted operation.
 

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -218,6 +218,13 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
         </body>
     </html>
 
+Template sandbox restrictions
+=============================
+
+Mautic renders user-uploaded Theme templates in a restricted Twig sandbox environment. Certain functions and filters that could enable remote code execution, data leakage, or filesystem probing are blocked.
+
+If your Theme template uses a restricted function or filter, Mautic throws an exception such as ``SecurityNotAllowedFilterError`` or ``SecurityNotAllowedFunctionError``. Use alternative approaches that don't require the restricted operation.
+
 Thumbnails
 ==========
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/b56bfcbf-c65f-44af-aafd-265ffd55a390)

Adds a concise, generic section documenting that Mautic renders user-uploaded Theme templates in a restricted Twig sandbox environment. Follows maintainer guidance to avoid exposing implementation details of blocked functions and filters.

**Trigger Events**
- New Task: Please update the docs based on this PR at mautic/mautic: https://github.com/mautic/mautic/pull/16173. Note from the PR poster to update the docs:...

---

_Tip: Send Promptless a meeting transcript in Slack to generate doc updates 📝_