### PR TITLE
Document Form submission limit API fields

### DIFF
--- a/docs/rest_api/forms.rst
+++ b/docs/rest_api/forms.rst
@@ -155,7 +155,10 @@ Response
           "postActionProperty": "Thank you for registering and see you there!",
           "noIndex": false,
           "formAttributes": null,
-          "language": "en_US"
+          "language": "en_US",
+          "submissionLimit": 100,
+          "submissionLimitMessage": "This form is no longer accepting submissions.",
+          "submissionCount": 42
       }
    }
 
@@ -255,6 +258,15 @@ Form properties
    * - ``language``
      - string
      - The language code for the Form, such as ``en_US``, ``fr``, and so on
+   * - ``submissionLimit``
+     - integer
+     - Maximum number of submissions allowed for this Form. When the limit is reached, the Form stops accepting new submissions. Set to ``null`` for unlimited submissions
+   * - ``submissionLimitMessage``
+     - string
+     - Custom message displayed when the submission limit is reached. When not set, Mautic displays a default message
+   * - ``submissionCount``
+     - integer
+     - **Read-only.** Current number of submissions for the Form. Mautic increments this value when a submission is saved and decrements it when a submission is deleted
 
 .. vale on
 
@@ -540,7 +552,10 @@ Response
               "postActionProperty": "Thank you for registering and see you there!",
               "noIndex": false,
               "formAttributes": null,
-              "language": "en_US"
+              "language": "en_US",
+              "submissionLimit": 100,
+              "submissionLimitMessage": "This form is no longer accepting submissions.",
+              "submissionCount": 42
           },
           // ...
       ]
@@ -671,6 +686,12 @@ POST parameters
    * - ``isPublished``
      - boolean
      - Form publication status
+   * - ``submissionLimit``
+     - integer
+     - Maximum number of submissions allowed for the Form. When the limit is reached, the Form stops accepting new submissions
+   * - ``submissionLimitMessage``
+     - string
+     - Custom message displayed when the submission limit is reached
 
 .. _Field parameters:
 

--- a/docs/rest_api/forms.rst
+++ b/docs/rest_api/forms.rst
@@ -260,13 +260,13 @@ Form properties
      - The language code for the Form, such as ``en_US``, ``fr``, and so on
    * - ``submissionLimit``
      - integer
-     - Maximum number of submissions allowed for this Form. When the limit is reached, the Form stops accepting new submissions. Set to ``null`` for unlimited submissions
+     - Maximum number of submissions allowed for this Form. When the Form reaches this limit, it stops accepting new submissions. Set to ``null`` for unlimited submissions
    * - ``submissionLimitMessage``
      - string
-     - Custom message displayed when the submission limit is reached. When not set, Mautic displays a default message
+     - Custom message displayed when the Form reaches its submission limit. When not set, Mautic displays a default message
    * - ``submissionCount``
      - integer
-     - **Read-only.** Current number of submissions for the Form. Mautic increments this value when a submission is saved and decrements it when a submission is deleted
+     - **Read-only.** Current number of submissions for the Form. Mautic increments this value when it saves a submission and decrements it when you delete a submission
 
 .. vale on
 
@@ -688,10 +688,10 @@ POST parameters
      - Form publication status
    * - ``submissionLimit``
      - integer
-     - Maximum number of submissions allowed for the Form. When the limit is reached, the Form stops accepting new submissions
+     - Maximum number of submissions allowed for the Form. When the Form reaches this limit, it stops accepting new submissions
    * - ``submissionLimitMessage``
      - string
-     - Custom message displayed when the submission limit is reached
+     - Custom message displayed when the Form reaches its submission limit
 
 .. _Field parameters:
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/8295b284-3bb1-45b4-80a8-ac8cb9d47f26)

Documents the new submission limit fields added to the Forms API in Mautic 7 via mautic/mautic#15396: submissionLimit, submissionLimitMessage (read/write), and submissionCount (read-only). Updates JSON examples and property tables.

**Trigger Events**
- [mautic/mautic PR #15396: Configurable form submission limit](https://github.com/mautic/mautic/pull/15396)

---

_Tip: Adjust how proactive or focused Promptless is in [Agent Settings](https://app.gopromptless.ai/configure/settings) ⚙️_