### PR TITLE
Document theme template sandbox restrictions (7.x)

### DIFF
--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -218,6 +218,13 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
         </body>
     </html>
 
+Template sandbox restrictions
+=============================
+
+Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment. The sandbox blocks certain functions and filters that could enable remote code execution, data leakage, or filesystem probing.
+
+If your Theme template uses a restricted function or filter, Mautic throws an exception such as ``SecurityNotAllowedFilterError`` or ``SecurityNotAllowedFunctionError``. Use alternative approaches that don't require the restricted operation.
+
 Thumbnails
 ==========
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/e9f2747f-0810-4a94-a255-b78876636b15)

Ports the theme template sandbox documentation from 5.x to 7.x branch. Documents that Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment that blocks potentially dangerous functions and filters.

---

_Tip: Request one-off documentation tasks in the Dashboard under [New Task](https://app.gopromptless.ai/new-task) 🚀_