### PR TITLE
Document MauticJS tracking API functions for contact-specific content

### DIFF
--- a/docs/mauticjs_api/tracking_script.rst
+++ b/docs/mauticjs_api/tracking_script.rst
@@ -447,7 +447,7 @@ This method inserts a script tag with the provided URL in the head of your docum
 ========================================
 
 This method sets the tracked Contact from an API response object.
-The response object must contain ``id`` (the Contact ID) and ``sid`` or ``device_id`` (the device tracking ID).
+The response object must contain ``id`` - the Contact ID - and ``sid`` or ``device_id`` - the device tracking ID.
 Mautic uses this internally when tracking endpoint responses include updated Contact identification.
 
 .. code-block:: js
@@ -464,9 +464,7 @@ Mautic uses this internally when tracking endpoint responses include updated Con
 ``MauticJS.beforeFirstEventDelivery(callback)``
 ===============================================
 
-This method registers a callback function that runs before the first tracking event gets delivered to Mautic.
-Use it when you need to perform actions after tracking initializes but before any events fire.
-It's useful for loading additional content based on the tracked Contact's profile.
+This method registers a callback that runs after tracking initializes but before MauticJS delivers the first tracking event to Mautic, which is useful for loading additional content based on the tracked Contact's profile.
 
 .. code-block:: js
 

--- a/docs/mauticjs_api/tracking_script.rst
+++ b/docs/mauticjs_api/tracking_script.rst
@@ -442,3 +442,35 @@ This method inserts a script tag with the provided URL in the head of your docum
 .. code-block:: js
 
    MauticJS.insertScript('http://google.com/ga.js');
+
+``MauticJS.setTrackedContact(response)``
+========================================
+
+This method sets the tracked Contact from an API response object.
+The response object must contain ``id`` (the Contact ID) and ``sid`` or ``device_id`` (the device tracking ID).
+Mautic uses this internally when tracking endpoint responses include updated Contact identification.
+
+.. code-block:: js
+
+   // Example response structure from a tracking endpoint
+   var response = {
+       id: 123,        // Contact ID
+       sid: 'abc123',  // Session/device ID
+       device_id: 'abc123'
+   };
+
+   MauticJS.setTrackedContact(response);
+
+``MauticJS.beforeFirstEventDelivery(callback)``
+===============================================
+
+This method registers a callback function that runs before the first tracking event gets delivered to Mautic.
+Use it when you need to perform actions after tracking initializes but before any events fire.
+It's useful for loading additional content based on the tracked Contact's profile.
+
+.. code-block:: js
+
+   MauticJS.beforeFirstEventDelivery(function() {
+       // This runs after mtc.js initializes but before the first tracking event
+       console.log('Ready to load contact-specific content');
+   });

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ sphinx_rtd_theme==3.1.0
 readthedocs-sphinx-search==0.3.2
 rstcheck==6.3.0
 myst-parser==5.1.0
-linkify-it-py==2.1.1
+linkify-it-py==2.2.0
 esbonio==2.1.0
 attrs==26.1.0
 sphinxcontrib-phpdomain==0.15.2


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/81ea7c12-a962-4ae6-b9f2-942ac7d218e6)

Adds documentation for `MauticJS.setTrackedContact()` and `MauticJS.beforeFirstEventDelivery()` API functions that enable loading contact-specific content via the tracking script.

**Trigger Events**
- [mautic/mautic PR #16228: Contact filters for focus items delivered via tracking script](https://github.com/mautic/mautic/pull/16228)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_