### PR TITLE
Document toggle publish events for Emails and Pages

### DIFF
--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -508,6 +508,52 @@ Email stat helpers
 
 This section is in progress. See  ``\Mautic\EmailBundle\Stats\Helper\StatHelperInterface``
 
+Email lifecycle events
+----------------------
+
+Mautic dispatches events at key points in an Email's lifecycle. Plugins can use these events to react to or modify behavior when Emails are created, updated, deleted, or have their publish status changed.
+
+Toggle publish event
+====================
+
+The ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_TOGGLE_PUBLISH`` event dispatches when a User toggles the publish status of an Email. This occurs before Mautic persists the status change to the database, so plugins can perform actions or validations before the Email is published or unpublished.
+
+An event listener receives a ``Mautic\EmailBundle\Event\EmailEvent`` instance.
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/EmailLifecycleSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\EmailBundle\EmailEvents;
+    use Mautic\EmailBundle\Event\EmailEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    final class EmailLifecycleSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                EmailEvents::EMAIL_ON_TOGGLE_PUBLISH => ['onEmailTogglePublish', 0],
+            ];
+        }
+
+        public function onEmailTogglePublish(EmailEvent $event): void
+        {
+            $email = $event->getEmail();
+
+            // Check current publish status (before toggle)
+            $isCurrentlyPublished = $email->isPublished();
+
+            // Perform custom logic before the status changes
+            // For example, notify an external service
+        }
+    }
+
 .. vale off
 
 Testing Email transports

--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -513,7 +513,7 @@ Email lifecycle events
 
 .. vale off
 
-Mautic dispatches events at key points in an Email's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the Active status of an Email.
+Mautic dispatches events at key points in an Email's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the **Active** status of an Email.
 
 .. vale on
 

--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -511,7 +511,11 @@ This section is in progress. See  ``\Mautic\EmailBundle\Stats\Helper\StatHelperI
 Email lifecycle events
 ----------------------
 
+.. vale off
+
 Mautic dispatches events at key points in an Email's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the Active status of an Email.
+
+.. vale on
 
 .. vale off
 

--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -511,12 +511,16 @@ This section is in progress. See  ``\Mautic\EmailBundle\Stats\Helper\StatHelperI
 Email lifecycle events
 ----------------------
 
-Mautic dispatches events at key points in an Email's lifecycle. Plugins can use these events to react to or modify behavior when Emails are created, updated, deleted, or have their publish status changed.
+Mautic dispatches events at key points in an Email's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the Active status of an Email.
 
-Toggle publish event
-====================
+.. vale off
 
-The ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_TOGGLE_PUBLISH`` event dispatches when a User toggles the publish status of an Email. This occurs before Mautic persists the status change to the database, so plugins can perform actions or validations before the Email is published or unpublished.
+Toggle 'Active' event
+=====================
+
+.. vale on
+
+The ``\Mautic\EmailBundle\EmailEvents::EMAIL_ON_TOGGLE_PUBLISH`` event dispatches when a User toggles the **Active** status of an Email. Mautic dispatches it before persisting the status change to the database, so Plugins can run actions or validations before the User activates or deactivates the Email.
 
 An event listener receives a ``Mautic\EmailBundle\Event\EmailEvent`` instance.
 

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -209,7 +209,7 @@ Landing Page lifecycle events
 
 .. vale off
 
-Mautic dispatches events at key points in a Landing Page's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the Available for use status of a Landing Page.
+Mautic dispatches events at key points in a Landing Page's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the **Available for use** status of a Landing Page.
 
 .. vale on
 

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -207,7 +207,11 @@ Landing Page lifecycle events
 
 .. vale on
 
+.. vale off
+
 Mautic dispatches events at key points in a Landing Page's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the Available for use status of a Landing Page.
+
+.. vale on
 
 .. vale off
 

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -199,3 +199,49 @@ The event provides:
 .. note::
 
    The ``TokenHelper::REGEX`` constant provides the regular expression pattern for matching Contact field tokens. Use this to check whether a URL contains tokens before performing replacements.
+
+Page lifecycle events
+*********************
+
+Mautic dispatches events at key points in a Page's lifecycle. Plugins can use these events to react to or modify behavior when Pages are created, updated, deleted, or have their publish status changed.
+
+Toggle publish event
+====================
+
+The ``\Mautic\PageBundle\PageEvents::PAGE_ON_TOGGLE_PUBLISH`` event dispatches when a User toggles the publish status of a Landing Page. This occurs before Mautic persists the status change to the database, so plugins can perform actions or validations before the Page is published or unpublished.
+
+An event listener receives a ``Mautic\PageBundle\Event\PageEvent`` instance.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/PageLifecycleSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\PageBundle\PageEvents;
+    use Mautic\PageBundle\Event\PageEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    final class PageLifecycleSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                PageEvents::PAGE_ON_TOGGLE_PUBLISH => ['onPageTogglePublish', 0],
+            ];
+        }
+
+        public function onPageTogglePublish(PageEvent $event): void
+        {
+            $page = $event->getPage();
+
+            // Check current publish status (before toggle)
+            $isCurrentlyPublished = $page->isPublished();
+
+            // Perform custom logic before the status changes
+            // For example, notify an external service or invalidate a cache
+        }
+    }

--- a/docs/plugin_extensions/landing_pages.rst
+++ b/docs/plugin_extensions/landing_pages.rst
@@ -200,15 +200,23 @@ The event provides:
 
    The ``TokenHelper::REGEX`` constant provides the regular expression pattern for matching Contact field tokens. Use this to check whether a URL contains tokens before performing replacements.
 
-Page lifecycle events
-*********************
+.. vale off
 
-Mautic dispatches events at key points in a Page's lifecycle. Plugins can use these events to react to or modify behavior when Pages are created, updated, deleted, or have their publish status changed.
+Landing Page lifecycle events
+*****************************
 
-Toggle publish event
-====================
+.. vale on
 
-The ``\Mautic\PageBundle\PageEvents::PAGE_ON_TOGGLE_PUBLISH`` event dispatches when a User toggles the publish status of a Landing Page. This occurs before Mautic persists the status change to the database, so plugins can perform actions or validations before the Page is published or unpublished.
+Mautic dispatches events at key points in a Landing Page's lifecycle. Plugins can use these events to react to or modify behavior when a User creates, updates, deletes, or changes the Available for use status of a Landing Page.
+
+.. vale off
+
+Toggle 'Available for use' event
+================================
+
+.. vale on
+
+The ``\Mautic\PageBundle\PageEvents::PAGE_ON_TOGGLE_PUBLISH`` event dispatches when a User toggles the **Available for use** status of a Landing Page. Mautic dispatches it before persisting the status change to the database, so Plugins can run actions or validations before the User makes the Landing Page available or unavailable.
 
 An event listener receives a ``Mautic\PageBundle\Event\PageEvent`` instance.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/f00e9298-855f-4b5b-bfa8-2d7af945e080)

Documents the new EMAIL_ON_TOGGLE_PUBLISH and PAGE_ON_TOGGLE_PUBLISH events introduced in mautic/mautic#16244. These events dispatch when a user toggles publish status, before the change persists to the database.

**Trigger Events**
- [mautic/mautic PR #16244: Toggle publish events for emails and pages](https://github.com/mautic/mautic/pull/16244)

---

_Tip: Enable auto-create PR in your [Docs Collection](https://app.gopromptless.ai/doc-collections) to review suggestions directly in GitHub 🤖_