### PR TITLE
Add SMS and MMS transport developer documentation

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -3,6 +3,9 @@ allowlist
 Amazon SES
 Ameling
 ascenders
+autoconfiguration
+autoconfigure
+autoconfigured
 autoloader
 Autoloader
 autowire

--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -47,6 +47,7 @@ DDEV
 DNC
 Do Not Contact
 Dripflow
+DTO
 Dynamic Web Content
 Esbonio
 FALSE
@@ -95,6 +96,7 @@ middleware
 Middlewares
 middlewares
 MJML
+MMS
 Multiselect
 multiselect
 MVC

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,6 +170,7 @@ There are several ways to support Mautic other than contributing with code.
    plugin_extensions/maintenance
    plugin_extensions/points
    plugin_extensions/reports
+   plugin_extensions/sms
    plugin_extensions/ui
    plugin_extensions/webhooks
 

--- a/docs/links/sms_transport_interfaces.py
+++ b/docs/links/sms_transport_interfaces.py
@@ -1,0 +1,36 @@
+from . import link
+
+link.xref_links.update({
+    "TransportInterface source": (
+        "TransportInterface",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/Sms/TransportInterface.php",
+    ),
+    "BulkTransportInterface source": (
+        "BulkTransportInterface",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/Sms/BulkTransportInterface.php",
+    ),
+    "MMSTransportInterface source": (
+        "MMSTransportInterface",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/Sms/MMSTransportInterface.php",
+    ),
+    "SmsRecipientDTO source": (
+        "SmsRecipientDTO",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/Helper/DTO/SmsRecipientDTO.php",
+    ),
+    "RecipientCollection source": (
+        "RecipientCollection",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/Collection/RecipientCollection.php",
+    ),
+    "SmsEvents source": (
+        "SmsEvents",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/SmsEvents.php",
+    ),
+    "FilterEvent source": (
+        "FilterEvent",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/Event/FilterEvent.php",
+    ),
+    "Twilio transport source": (
+        "TwilioTransport",
+        "https://github.com/mautic/mautic/blob/7.x/app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php",
+    ),
+})

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -1,7 +1,7 @@
 SMS and MMS
 ###########
 
-This document describes how to extend Mautic's SMS capabilities, including creating custom SMS transports, supporting bulk messaging, implementing MMS, and hooking into the Contact filtering pipeline.
+This document describes how to extend Mautic's SMS capabilities by building a custom transport in a Plugin. It walks through implementing the transport interfaces, adding bulk and MMS support, registering the transport, and hooking into the Contact filtering pipeline.
 
 .. vale off
 
@@ -11,132 +11,39 @@ This document describes how to extend Mautic's SMS capabilities, including creat
 
 .. vale on
 
-SMS transports
-**************
+Transport interfaces
+********************
 
-Mautic supports custom SMS transports through a set of interfaces. Each transport must implement at least ``TransportInterface`` and can optionally implement additional interfaces for bulk messaging and MMS support.
+A custom transport implements one or more interfaces from the ``Mautic\SmsBundle\Sms`` namespace, depending on the capabilities it provides. These interfaces live in Mautic core, so your Plugin implements them rather than redefining them.
+
+* :xref:`TransportInterface source` - the base interface every transport must implement. It defines ``sendSms(Lead $lead, $content)``, which sends a single message and returns ``true`` on success or an error message string on failure.
+* :xref:`BulkTransportInterface source` - extends ``TransportInterface`` to enable native batch sending through ``sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection``. Transports that implement only ``TransportInterface`` fall back to iterative per-Contact sending.
+* :xref:`MMSTransportInterface source` - adds MMS support with media attachments through ``sendMms(Lead $lead, string $content, array $media): bool|string``. Because of carrier restrictions, MMS currently works only for recipients in the US, Canada, and Australia.
+
+For the authoritative method signatures and documentation blocks, see the linked source files.
+
+Building a custom SMS transport
+*******************************
 
 .. vale off
 
-TransportInterface
-==================
+For the general Plugin layout, see the :doc:`Plugin structure</plugins/structure>` section.
 
 .. vale on
 
-This is the base interface for all SMS transports. Implement this interface to create a transport that sends SMS messages one at a time.
+The following worked example builds a transport inside a Plugin named ``HelloWorldBundle``. The transport-related files sit under the bundle's ``Sms/Transport`` directory::
 
-.. code-block:: php
+    plugins/HelloWorldBundle/
+        Config/
+            config.php
+        Sms/
+            Transport/
+                HelloWorldTransport.php
 
-   <?php
-
-   namespace Mautic\SmsBundle\Sms;
-
-   use Mautic\LeadBundle\Entity\Lead;
-
-   interface TransportInterface
-   {
-       /**
-        * @return bool|string Returns true on success or an error message
-        */
-       public function sendSms(Lead $lead, string $content);
-   }
-
-.. vale off
-
-BulkTransportInterface
-======================
-
-.. vale on
-
-Implement this interface to enable native batch SMS sending. Transports that only implement ``TransportInterface`` fall back to iterative per-Contact sending.
-
-.. code-block:: php
-
-   <?php
-
-   namespace Mautic\SmsBundle\Sms;
-
-   use Mautic\SmsBundle\Collection\RecipientCollection;
-
-   interface BulkTransportInterface extends TransportInterface
-   {
-       /**
-        * @param RecipientCollection<SmsRecipientDTO> $collection
-        *
-        * @return RecipientCollection<SmsRecipientDTO>
-        */
-       public function sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection;
-   }
-
-The ``RecipientCollection`` contains ``SmsRecipientDTO`` objects. After processing each recipient, call ``setResult(true)`` or ``setResult(false)`` on the Data Transfer Object - DTO - to indicate success or failure.
-
-.. vale off
-
-MMSTransportInterface
-=====================
-
-.. vale on
-
-Implement this interface to support MMS with media attachments. Currently, MMS works for recipients in the US, Canada, and Australia due to carrier restrictions.
-
-.. code-block:: php
-
-   <?php
-
-   namespace Mautic\SmsBundle\Sms;
-
-   use Mautic\LeadBundle\Entity\Lead;
-
-   interface MMSTransportInterface
-   {
-       /**
-        * @param array<mixed> $media Array of media URLs
-        *
-        * @return bool|string Returns true on success or an error message
-        */
-       public function sendMms(Lead $lead, string $content, array $media);
-   }
-
-MMS messages can include up to 10 media files with a combined maximum size of 5 MB. For external URLs, validate that media files meet size requirements since Mautic only enforces size limits for locally uploaded files.
-
-.. vale off
-
-Registering SMS transports
+Implementing the transport
 ==========================
 
-.. vale on
-
-Register a transport by tagging the service with ``mautic.sms_transport``. Set the ``integrationAlias`` argument to display the transport name in the UI.
-
-.. code-block:: php
-
-   <?php
-
-   // config/config.php
-   return [
-       'services' => [
-           'other' => [
-               'mautic.sms.transport.helloworld' => [
-                   'class'        => \MauticPlugin\HelloWorldBundle\Sms\Transport\HelloWorldTransport::class,
-                   'tag'          => 'mautic.sms_transport',
-                   'tagArguments' => [
-                       'integrationAlias' => 'Hello World SMS',
-                   ],
-               ],
-           ],
-       ],
-   ];
-
-To handle delivery callbacks from your transport provider, register a callback handler with the ``mautic.sms_callback_handler`` tag.
-
-.. vale off
-
-Example transport implementation
-================================
-
-.. vale on
-
-The following example shows an SMS transport implementing all three interfaces.
+Implement the interfaces for the capabilities your provider supports. The example below implements all three, so the transport handles single SMS, bulk SMS, and MMS.
 
 .. code-block:: php
 
@@ -155,15 +62,15 @@ The following example shows an SMS transport implementing all three interfaces.
 
    class HelloWorldTransport implements TransportInterface, BulkTransportInterface, MMSTransportInterface
    {
-       public function sendSms(Lead $lead, string $content)
+       public function sendSms(Lead $lead, $content)
        {
            $phone = $lead->getPhone();
            if (empty($phone)) {
                return 'No phone number available';
            }
 
-           // Send SMS through your provider
-           // Return true on success or an error message
+           // Send the SMS through your provider here.
+           // Return true on success or an error message string on failure.
            return true;
        }
 
@@ -171,84 +78,73 @@ The following example shows an SMS transport implementing all three interfaces.
        {
            foreach ($collection as $recipient) {
                $lead = $recipient->getLead();
-               // Get token substitution data for this recipient
-               $tokens = $recipient->getSubstitutionData();
 
-               // Send to your provider
-               $success = $this->sendToProvider($lead, $content);
+               // getFinalMessage() returns the message with tokens already
+               // replaced for this recipient.
+               $message = $recipient->getFinalMessage();
 
-               // Mark the result
+               $success = $this->sendToProvider($lead, $message);
+
+               // Record the outcome so Mautic can report per-Contact results.
                $recipient->setResult($success);
            }
 
            return $collection;
        }
 
-       public function sendMms(Lead $lead, string $content, array $media)
+       public function sendMms(Lead $lead, string $content, array $media): bool|string
        {
-           // Send MMS with media attachments
+           // Send the MMS with its media attachments here.
            return true;
        }
    }
 
-Recipient data structures
-*************************
+Registering the transport
+==========================
 
-When using bulk SMS, Mautic provides data structures to manage recipient lists and token substitution.
-
-.. vale off
-
-SmsRecipientDTO
-===============
-
-.. vale on
-
-The ``SmsRecipientDTO`` wraps each Contact with token substitution data.
+Register the transport in your Plugin's ``Config/config.php`` by tagging the service with ``mautic.sms_transport``. The ``integrationAlias`` tag argument sets the name shown in the UI.
 
 .. code-block:: php
 
    <?php
+   // plugins/HelloWorldBundle/Config/config.php
 
-   namespace Mautic\SmsBundle\Helper\DTO;
+   return [
+       'services' => [
+           'other' => [
+               'mautic.sms.transport.helloworld' => [
+                   'class'        => \MauticPlugin\HelloWorldBundle\Sms\Transport\HelloWorldTransport::class,
+                   'tag'          => 'mautic.sms_transport',
+                   'tagArguments' => [
+                       'integrationAlias' => 'Hello World SMS',
+                   ],
+               ],
+           ],
+       ],
+   ];
 
-   use Mautic\LeadBundle\Entity\Lead;
+To handle delivery callbacks from your provider, register a callback handler service with the ``mautic.sms_callback_handler`` tag. Mautic's built-in :xref:`Twilio transport source` is a useful reference for a complete transport and callback implementation.
 
-   final class SmsRecipientDTO implements \JsonSerializable
-   {
-       public function getKey(): int;      // Returns the lead ID
-       public function getLead(): Lead;    // Returns the contact entity
-       public function getResult(): bool;  // Check if send succeeded
-       public function setResult(bool $result): void;  // Set the send result
-       public function getSubstitutionData(): array;   // Get token values for this contact
-   }
+Bulk sending and recipient data
+********************************
 
-.. vale off
+When a transport implements ``BulkTransportInterface``, Mautic passes a :xref:`RecipientCollection source` to ``sendBatchSms()``. The collection extends ``\ArrayIterator``, so you can iterate it directly, and each item is an :xref:`SmsRecipientDTO source`.
 
-RecipientCollection
-===================
+Each Data Transfer Object (DTO) wraps one Contact together with its token data. The methods most relevant to a transport are:
 
-.. vale on
-
-The ``RecipientCollection`` is a typed collection of ``SmsRecipientDTO`` objects that implements ``ArrayIterator``.
-
-.. code-block:: php
-
-   <?php
-
-   namespace Mautic\SmsBundle\Collection;
-
-   final class RecipientCollection extends \ArrayIterator
-   {
-       public function toChoices(): array;                    // Convert to choices array
-       public function getFieldByKey(int $key): SmsRecipientDTO;  // Get recipient by lead ID
-   }
+* ``getLead()`` - Returns the ``Lead`` entity for this recipient.
+* ``getFinalMessage()`` - Returns the message body with tokens already replaced for this recipient.
+* ``getSubstitutionData()`` - Returns the raw token values, useful for providers that perform their own substitution.
+* ``setResult(bool $result)`` - Records whether the send succeeded so Mautic can report per-Contact outcomes.
 
 Contact filtering events
 ************************
 
-Three events fire sequentially during SMS sending to filter Contacts before dispatch. Use these events to exclude Contacts based on custom criteria.
+Three events fire sequentially during SMS sending to filter Contacts before dispatch. Subscribe to them to exclude Contacts based on custom criteria.
 
 .. vale off
+
+For how to register a subscriber, see the :doc:`listeners and subscribers</plugins/event_listeners>` section.
 
 Do Not Contact filter
 =====================
@@ -276,9 +172,7 @@ Use ``SmsEvents::DNC_FILTER_CONTACTS_ON_SEND`` to filter Contacts based on **Do 
 
        public function onDncFilter(DncEvent $event): void
        {
-           $contacts = $event->getContacts();
-
-           foreach ($contacts as $id => $contact) {
+           foreach ($event->getContacts() as $id => $contact) {
                if ($this->shouldExclude($contact)) {
                    $event->removeContact($id);
                }
@@ -289,104 +183,47 @@ Use ``SmsEvents::DNC_FILTER_CONTACTS_ON_SEND`` to filter Contacts based on **Do 
 Queue filter
 ============
 
-Use ``SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND`` to filter contacts based on frequency rules or queueing logic.
-
-.. code-block:: php
-
-   <?php
-
-   use Mautic\SmsBundle\Event\QueueEvent;
-   use Mautic\SmsBundle\SmsEvents;
-
-   // In your subscriber
-   public static function getSubscribedEvents(): array
-   {
-       return [
-           SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND => ['onQueueFilter', 0],
-       ];
-   }
-
-   public function onQueueFilter(QueueEvent $event): void
-   {
-       // Filter contacts based on frequency rules
-   }
+Use ``SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND`` to filter Contacts based on frequency rules or queueing logic. Subscribe to it the same way, with a listener that receives a ``QueueEvent``.
 
 Generic filter
 ==============
 
-Use ``SmsEvents::FILTER_CONTACTS_ON_SEND`` for any remaining filtering logic, such as removing Contacts without phone numbers.
+Use ``SmsEvents::FILTER_CONTACTS_ON_SEND`` for any remaining filtering logic, such as removing Contacts without phone numbers. Its listener receives a ``FilterEvent``.
 
-.. code-block:: php
-
-   <?php
-
-   use Mautic\SmsBundle\Event\FilterEvent;
-   use Mautic\SmsBundle\SmsEvents;
-
-   // In your subscriber
-   public static function getSubscribedEvents(): array
-   {
-       return [
-           SmsEvents::FILTER_CONTACTS_ON_SEND => ['onFilter', 0],
-       ];
-   }
-
-   public function onFilter(FilterEvent $event): void
-   {
-       // Remove contacts that shouldn't receive SMS
-       $removedContacts = $event->getRemovedContacts();
-   }
-
-All three event classes share a common API:
+All three event classes share a common API, shown here for :xref:`FilterEvent source`:
 
 * ``getContacts()`` - Returns the array of Contacts
 * ``removeContact(int $id)`` - Remove a single Contact by ID
 * ``removeContacts(array $contacts)`` - Remove multiple Contacts
 * ``getRemovedContacts()`` - Get the list of removed Contacts
 
-.. vale off
-
 Campaign SMS events
 *******************
-
-.. vale on
 
 When integrating SMS with Campaigns, use the batch Campaign action event for better performance.
 
 Batch action event
 ==================
 
-Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle Campaign SMS actions.
+Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle Campaign SMS actions. Set it as the ``batchEventName`` when registering the action on ``CampaignEvents::CAMPAIGN_ON_BUILD``. See :doc:`/plugin_extensions/campaigns` for the full Campaign action workflow.
 
 .. code-block:: php
 
    <?php
 
    use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
-   use Mautic\CampaignBundle\CampaignEvents;
    use Mautic\SmsBundle\SmsEvents;
-   use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-   class CampaignSubscriber implements EventSubscriberInterface
+   public function onCampaignBuild(CampaignBuilderEvent $event): void
    {
-       public static function getSubscribedEvents(): array
-       {
-           return [
-               CampaignEvents::CAMPAIGN_ON_BUILD => ['onCampaignBuild', 0],
-           ];
-       }
-
-       public function onCampaignBuild(CampaignBuilderEvent $event): void
-       {
-           $event->addAction(
-               'my_plugin.send_sms',
-               [
-                   'label'          => 'Send Custom SMS',
-                   'batchEventName' => SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION,
-                   // Other configuration...
-               ]
-           );
-       }
+       $event->addAction(
+           'my_plugin.send_sms',
+           [
+               'label'          => 'Send Custom SMS',
+               'batchEventName' => SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION,
+               // Other configuration...
+           ]
+       );
    }
 
 Deprecation notice
@@ -394,16 +231,12 @@ Deprecation notice
 
 .. deprecated:: 7.0
 
-   Mautic deprecates ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION``. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch contact processing.
-
-.. vale off
+   Mautic deprecates ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION``. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch Contact processing.
 
 SMS event constants
 *******************
 
-.. vale on
-
-The ``SmsEvents`` class defines all SMS-related event constants:
+The :xref:`SmsEvents source` class defines all SMS-related event constants:
 
 .. vale off
 

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -132,10 +132,14 @@ When a transport implements ``BulkTransportInterface``, Mautic passes a :xref:`R
 
 Each Data Transfer Object (DTO) wraps one Contact together with its token data. The methods most relevant to a transport are:
 
+.. vale off
+
 * ``getLead()`` - Returns the ``Lead`` entity for this recipient.
 * ``getFinalMessage()`` - Returns the message body with tokens already replaced for this recipient.
 * ``getSubstitutionData()`` - Returns the raw token values, useful for providers that perform their own substitution.
 * ``setResult(bool $result)`` - Records whether the send succeeded so Mautic can report per-Contact outcomes.
+
+.. vale on
 
 Contact filtering events
 ************************

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -102,7 +102,7 @@ Implement the interfaces for the capabilities your provider supports. The exampl
 Registering the transport
 ==========================
 
-Register the transport in your Plugin's ``Config/config.php`` by tagging the service with ``mautic.sms_transport``. The ``integrationAlias`` tag argument sets the name shown in the UI.
+Register the transport in your Plugin's ``Config/config.php`` by tagging the service with ``mautic.sms_transport``. Mautic builds Plugin ``config.php`` services through its own ``ServicePass`` compiler pass rather than Symfony autoconfiguration, so implementing ``TransportInterface`` doesn't tag the service for you, and you must declare the tag explicitly. The ``SmsTransportPass`` compiler pass then collects every service carrying this tag, and the ``integrationAlias`` tag argument sets the name shown in the UI.
 
 .. code-block:: php
 
@@ -157,11 +157,13 @@ Use ``SmsEvents::DNC_FILTER_CONTACTS_ON_SEND`` to filter Contacts based on **Do 
 
    <?php
 
+   declare(strict_types=1);
+
    use Mautic\SmsBundle\Event\DncEvent;
    use Mautic\SmsBundle\SmsEvents;
    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-   class SmsFilterSubscriber implements EventSubscriberInterface
+   final class SmsFilterSubscriber implements EventSubscriberInterface
    {
        public static function getSubscribedEvents(): array
        {

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -405,6 +405,8 @@ SMS event constants
 
 The ``SmsEvents`` class defines all SMS-related event constants:
 
+.. vale off
+
 .. list-table::
    :header-rows: 1
    :widths: 40 60
@@ -412,7 +414,7 @@ The ``SmsEvents`` class defines all SMS-related event constants:
    * - Event constant
      - Description
    * - ``ON_CAMPAIGN_TRIGGER_BATCH_ACTION``
-     - Fires when a campaign triggers an SMS action for a batch of Contacts.
+     - Fires when a Campaign triggers an SMS action for a batch of Contacts.
    * - ``ON_CAMPAIGN_TRIGGER_ACTION``
      - **Deprecated.** Legacy event for single-Contact Campaign SMS actions.
    * - ``DNC_FILTER_CONTACTS_ON_SEND``
@@ -421,3 +423,5 @@ The ``SmsEvents`` class defines all SMS-related event constants:
      - Fires to filter Contacts based on frequency rules.
    * - ``FILTER_CONTACTS_ON_SEND``
      - Fires for generic Contact filtering before SMS dispatch.
+
+.. vale on

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -1,13 +1,13 @@
 SMS and MMS
 ###########
 
-This document describes how to extend Mautic's SMS capabilities, including creating custom SMS transports, supporting bulk messaging, implementing MMS, and hooking into the contact filtering pipeline.
+This document describes how to extend Mautic's SMS capabilities, including creating custom SMS transports, supporting bulk messaging, implementing MMS, and hooking into the Contact filtering pipeline.
 
 .. vale off
 
 .. note::
 
-   Extending generally works by hooking into events using event listeners or subscribers. Read more about them in the :doc:`listeners and subscribers</plugins/event_listeners>` section.
+   Extending generally works by hooking into events using event listeners or subscribers. Read more about them in the :doc:`/plugins/event_listeners` section.
 
 .. vale on
 
@@ -48,7 +48,7 @@ BulkTransportInterface
 
 .. vale on
 
-Implement this interface to enable native batch SMS sending. Transports that only implement ``TransportInterface`` fall back to iterative per-contact sending.
+Implement this interface to enable native batch SMS sending. Transports that only implement ``TransportInterface`` fall back to iterative per-Contact sending.
 
 .. code-block:: php
 
@@ -68,7 +68,7 @@ Implement this interface to enable native batch SMS sending. Transports that onl
        public function sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection;
    }
 
-The ``RecipientCollection`` contains ``SmsRecipientDTO`` objects. After processing each recipient, call ``setResult(true)`` or ``setResult(false)`` on the DTO to indicate success or failure.
+The ``RecipientCollection`` contains ``SmsRecipientDTO`` objects. After processing each recipient, call ``setResult(true)`` or ``setResult(false)`` on the Data Transfer Object (DTO) to indicate success or failure.
 
 .. vale off
 
@@ -191,12 +191,8 @@ The following example shows an SMS transport implementing all three interfaces.
        }
    }
 
-.. vale off
-
 Recipient data structures
 *************************
-
-.. vale on
 
 When using bulk SMS, Mautic provides data structures to manage recipient lists and token substitution.
 
@@ -207,7 +203,7 @@ SmsRecipientDTO
 
 .. vale on
 
-The ``SmsRecipientDTO`` wraps each contact with token substitution data.
+The ``SmsRecipientDTO`` wraps each Contact with token substitution data.
 
 .. code-block:: php
 
@@ -247,23 +243,19 @@ The ``RecipientCollection`` is a typed collection of ``SmsRecipientDTO`` objects
        public function getFieldByKey(int $key): SmsRecipientDTO;  // Get recipient by lead ID
    }
 
-.. vale off
-
 Contact filtering events
 ************************
 
-.. vale on
-
-Three events fire sequentially during SMS sending to filter contacts before dispatch. Use these events to exclude contacts based on custom criteria.
+Three events fire sequentially during SMS sending to filter Contacts before dispatch. Use these events to exclude Contacts based on custom criteria.
 
 .. vale off
 
 Do Not Contact filter
 =====================
 
-.. vale on
+Use ``SmsEvents::DNC_FILTER_CONTACTS_ON_SEND`` to filter Contacts based on **Do Not Contact** status.
 
-Use ``SmsEvents::DNC_FILTER_CONTACTS_ON_SEND`` to filter contacts based on Do Not Contact status.
+.. vale on
 
 .. code-block:: php
 
@@ -294,12 +286,8 @@ Use ``SmsEvents::DNC_FILTER_CONTACTS_ON_SEND`` to filter contacts based on Do No
        }
    }
 
-.. vale off
-
 Queue filter
 ============
-
-.. vale on
 
 Use ``SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND`` to filter contacts based on frequency rules or queueing logic.
 
@@ -323,14 +311,10 @@ Use ``SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND`` to filter contacts based on fre
        // Filter contacts based on frequency rules
    }
 
-.. vale off
-
 Generic filter
 ==============
 
-.. vale on
-
-Use ``SmsEvents::FILTER_CONTACTS_ON_SEND`` for any remaining filtering logic, such as removing contacts without phone numbers.
+Use ``SmsEvents::FILTER_CONTACTS_ON_SEND`` for any remaining filtering logic, such as removing Contacts without phone numbers.
 
 .. code-block:: php
 
@@ -355,10 +339,10 @@ Use ``SmsEvents::FILTER_CONTACTS_ON_SEND`` for any remaining filtering logic, su
 
 All three event classes share a common API:
 
-- ``getContacts()`` - Returns the array of contacts
-- ``removeContact(int $id)`` - Remove a single contact by ID
-- ``removeContacts(array $contacts)`` - Remove multiple contacts
-- ``getRemovedContacts()`` - Get the list of removed contacts
+* ``getContacts()`` - Returns the array of Contacts
+* ``removeContact(int $id)`` - Remove a single Contact by ID
+* ``removeContacts(array $contacts)`` - Remove multiple Contacts
+* ``getRemovedContacts()`` - Get the list of removed Contacts
 
 .. vale off
 
@@ -367,16 +351,12 @@ Campaign SMS events
 
 .. vale on
 
-When integrating SMS with campaigns, use the batch campaign action event for better performance.
-
-.. vale off
+When integrating SMS with Campaigns, use the batch Campaign action event for better performance.
 
 Batch action event
 ==================
 
-.. vale on
-
-Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle campaign SMS actions.
+Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle Campaign SMS actions.
 
 .. code-block:: php
 
@@ -409,16 +389,12 @@ Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle campaign SMS actio
        }
    }
 
-.. vale off
-
 Deprecation notice
 ==================
 
-.. vale on
-
 .. deprecated:: 7.0
 
-   ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION`` is deprecated. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch contact processing.
+   Mautic deprecates ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION``. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch contact processing.
 
 .. vale off
 
@@ -436,12 +412,12 @@ The ``SmsEvents`` class defines all SMS-related event constants:
    * - Event constant
      - Description
    * - ``ON_CAMPAIGN_TRIGGER_BATCH_ACTION``
-     - Fires when a campaign triggers an SMS action for a batch of contacts.
+     - Fires when a campaign triggers an SMS action for a batch of Contacts.
    * - ``ON_CAMPAIGN_TRIGGER_ACTION``
-     - **Deprecated.** Legacy event for single-contact campaign SMS actions.
+     - **Deprecated.** Legacy event for single-Contact Campaign SMS actions.
    * - ``DNC_FILTER_CONTACTS_ON_SEND``
-     - Fires to filter contacts based on Do Not Contact status.
+     - Fires to filter Contacts based on **Do Not Contact** status.
    * - ``QUEUE_FILTER_CONTACTS_ON_SEND``
-     - Fires to filter contacts based on frequency rules.
+     - Fires to filter Contacts based on frequency rules.
    * - ``FILTER_CONTACTS_ON_SEND``
-     - Fires for generic contact filtering before SMS dispatch.
+     - Fires for generic Contact filtering before SMS dispatch.

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -31,14 +31,16 @@ For the general Plugin layout, see the :doc:`Plugin structure</plugins/structure
 
 .. vale on
 
-The worked example below builds a transport inside a Plugin named ``HelloWorldBundle``. The transport-related files sit under the bundle's ``Sms/Transport`` directory::
+The worked example below builds a transport inside a Plugin named ``HelloWorldBundle``. The transport-related files sit under the bundle's ``Sms/Transport`` directory:
 
-    plugins/HelloWorldBundle/
-        Config/
-            config.php
-        Sms/
-            Transport/
-                HelloWorldTransport.php
+.. code-block:: text
+
+   plugins/HelloWorldBundle/
+   ├── Config/
+   │   └── config.php
+   └── Sms/
+       └── Transport/
+           └── HelloWorldTransport.php
 
 Implementing the transport
 ==========================

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -1,0 +1,447 @@
+SMS and MMS
+###########
+
+This document describes how to extend Mautic's SMS capabilities, including creating custom SMS transports, supporting bulk messaging, implementing MMS, and hooking into the contact filtering pipeline.
+
+.. vale off
+
+.. note::
+
+   Extending generally works by hooking into events using event listeners or subscribers. Read more about them in the :doc:`listeners and subscribers</plugins/event_listeners>` section.
+
+.. vale on
+
+SMS transports
+**************
+
+Mautic supports custom SMS transports through a set of interfaces. Each transport must implement at least ``TransportInterface`` and can optionally implement additional interfaces for bulk messaging and MMS support.
+
+.. vale off
+
+TransportInterface
+==================
+
+.. vale on
+
+This is the base interface for all SMS transports. Implement this interface to create a transport that sends SMS messages one at a time.
+
+.. code-block:: php
+
+   <?php
+
+   namespace Mautic\SmsBundle\Sms;
+
+   use Mautic\LeadBundle\Entity\Lead;
+
+   interface TransportInterface
+   {
+       /**
+        * @return bool|string Returns true on success or an error message
+        */
+       public function sendSms(Lead $lead, string $content);
+   }
+
+.. vale off
+
+BulkTransportInterface
+======================
+
+.. vale on
+
+Implement this interface to enable native batch SMS sending. Transports that only implement ``TransportInterface`` fall back to iterative per-contact sending.
+
+.. code-block:: php
+
+   <?php
+
+   namespace Mautic\SmsBundle\Sms;
+
+   use Mautic\SmsBundle\Collection\RecipientCollection;
+
+   interface BulkTransportInterface extends TransportInterface
+   {
+       /**
+        * @param RecipientCollection<SmsRecipientDTO> $collection
+        *
+        * @return RecipientCollection<SmsRecipientDTO>
+        */
+       public function sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection;
+   }
+
+The ``RecipientCollection`` contains ``SmsRecipientDTO`` objects. After processing each recipient, call ``setResult(true)`` or ``setResult(false)`` on the DTO to indicate success or failure.
+
+.. vale off
+
+MMSTransportInterface
+=====================
+
+.. vale on
+
+Implement this interface to support MMS with media attachments. Currently, MMS works for recipients in the US, Canada, and Australia due to carrier restrictions.
+
+.. code-block:: php
+
+   <?php
+
+   namespace Mautic\SmsBundle\Sms;
+
+   use Mautic\LeadBundle\Entity\Lead;
+
+   interface MMSTransportInterface
+   {
+       /**
+        * @param array<mixed> $media Array of media URLs
+        *
+        * @return bool|string Returns true on success or an error message
+        */
+       public function sendMms(Lead $lead, string $content, array $media);
+   }
+
+MMS messages can include up to 10 media files with a combined maximum size of 5 MB. For external URLs, validate that media files meet size requirements since Mautic only enforces size limits for locally uploaded files.
+
+.. vale off
+
+Registering SMS transports
+==========================
+
+.. vale on
+
+Register a transport by tagging the service with ``mautic.sms_transport``. Set the ``integrationAlias`` argument to display the transport name in the UI.
+
+.. code-block:: php
+
+   <?php
+
+   // config/config.php
+   return [
+       'services' => [
+           'other' => [
+               'mautic.sms.transport.helloworld' => [
+                   'class'        => \MauticPlugin\HelloWorldBundle\Sms\Transport\HelloWorldTransport::class,
+                   'tag'          => 'mautic.sms_transport',
+                   'tagArguments' => [
+                       'integrationAlias' => 'Hello World SMS',
+                   ],
+               ],
+           ],
+       ],
+   ];
+
+To handle delivery callbacks from your transport provider, register a callback handler with the ``mautic.sms_callback_handler`` tag.
+
+.. vale off
+
+Example transport implementation
+================================
+
+.. vale on
+
+The following example shows an SMS transport implementing all three interfaces.
+
+.. code-block:: php
+
+   <?php
+   // plugins/HelloWorldBundle/Sms/Transport/HelloWorldTransport.php
+
+   declare(strict_types=1);
+
+   namespace MauticPlugin\HelloWorldBundle\Sms\Transport;
+
+   use Mautic\LeadBundle\Entity\Lead;
+   use Mautic\SmsBundle\Collection\RecipientCollection;
+   use Mautic\SmsBundle\Sms\BulkTransportInterface;
+   use Mautic\SmsBundle\Sms\MMSTransportInterface;
+   use Mautic\SmsBundle\Sms\TransportInterface;
+
+   class HelloWorldTransport implements TransportInterface, BulkTransportInterface, MMSTransportInterface
+   {
+       public function sendSms(Lead $lead, string $content)
+       {
+           $phone = $lead->getPhone();
+           if (empty($phone)) {
+               return 'No phone number available';
+           }
+
+           // Send SMS through your provider
+           // Return true on success or an error message
+           return true;
+       }
+
+       public function sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection
+       {
+           foreach ($collection as $recipient) {
+               $lead = $recipient->getLead();
+               // Get token substitution data for this recipient
+               $tokens = $recipient->getSubstitutionData();
+
+               // Send to your provider
+               $success = $this->sendToProvider($lead, $content);
+
+               // Mark the result
+               $recipient->setResult($success);
+           }
+
+           return $collection;
+       }
+
+       public function sendMms(Lead $lead, string $content, array $media)
+       {
+           // Send MMS with media attachments
+           return true;
+       }
+   }
+
+.. vale off
+
+Recipient data structures
+*************************
+
+.. vale on
+
+When using bulk SMS, Mautic provides data structures to manage recipient lists and token substitution.
+
+.. vale off
+
+SmsRecipientDTO
+===============
+
+.. vale on
+
+The ``SmsRecipientDTO`` wraps each contact with token substitution data.
+
+.. code-block:: php
+
+   <?php
+
+   namespace Mautic\SmsBundle\Helper\DTO;
+
+   use Mautic\LeadBundle\Entity\Lead;
+
+   final class SmsRecipientDTO implements \JsonSerializable
+   {
+       public function getKey(): int;      // Returns the lead ID
+       public function getLead(): Lead;    // Returns the contact entity
+       public function getResult(): bool;  // Check if send succeeded
+       public function setResult(bool $result): void;  // Set the send result
+       public function getSubstitutionData(): array;   // Get token values for this contact
+   }
+
+.. vale off
+
+RecipientCollection
+===================
+
+.. vale on
+
+The ``RecipientCollection`` is a typed collection of ``SmsRecipientDTO`` objects that implements ``ArrayIterator``.
+
+.. code-block:: php
+
+   <?php
+
+   namespace Mautic\SmsBundle\Collection;
+
+   final class RecipientCollection extends \ArrayIterator
+   {
+       public function toChoices(): array;                    // Convert to choices array
+       public function getFieldByKey(int $key): SmsRecipientDTO;  // Get recipient by lead ID
+   }
+
+.. vale off
+
+Contact filtering events
+************************
+
+.. vale on
+
+Three events fire sequentially during SMS sending to filter contacts before dispatch. Use these events to exclude contacts based on custom criteria.
+
+.. vale off
+
+Do Not Contact filter
+=====================
+
+.. vale on
+
+Use ``SmsEvents::DNC_FILTER_CONTACTS_ON_SEND`` to filter contacts based on Do Not Contact status.
+
+.. code-block:: php
+
+   <?php
+
+   use Mautic\SmsBundle\Event\DncEvent;
+   use Mautic\SmsBundle\SmsEvents;
+   use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+   class SmsFilterSubscriber implements EventSubscriberInterface
+   {
+       public static function getSubscribedEvents(): array
+       {
+           return [
+               SmsEvents::DNC_FILTER_CONTACTS_ON_SEND => ['onDncFilter', 0],
+           ];
+       }
+
+       public function onDncFilter(DncEvent $event): void
+       {
+           $contacts = $event->getContacts();
+
+           foreach ($contacts as $id => $contact) {
+               if ($this->shouldExclude($contact)) {
+                   $event->removeContact($id);
+               }
+           }
+       }
+   }
+
+.. vale off
+
+Queue filter
+============
+
+.. vale on
+
+Use ``SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND`` to filter contacts based on frequency rules or queueing logic.
+
+.. code-block:: php
+
+   <?php
+
+   use Mautic\SmsBundle\Event\QueueEvent;
+   use Mautic\SmsBundle\SmsEvents;
+
+   // In your subscriber
+   public static function getSubscribedEvents(): array
+   {
+       return [
+           SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND => ['onQueueFilter', 0],
+       ];
+   }
+
+   public function onQueueFilter(QueueEvent $event): void
+   {
+       // Filter contacts based on frequency rules
+   }
+
+.. vale off
+
+Generic filter
+==============
+
+.. vale on
+
+Use ``SmsEvents::FILTER_CONTACTS_ON_SEND`` for any remaining filtering logic, such as removing contacts without phone numbers.
+
+.. code-block:: php
+
+   <?php
+
+   use Mautic\SmsBundle\Event\FilterEvent;
+   use Mautic\SmsBundle\SmsEvents;
+
+   // In your subscriber
+   public static function getSubscribedEvents(): array
+   {
+       return [
+           SmsEvents::FILTER_CONTACTS_ON_SEND => ['onFilter', 0],
+       ];
+   }
+
+   public function onFilter(FilterEvent $event): void
+   {
+       // Remove contacts that shouldn't receive SMS
+       $removedContacts = $event->getRemovedContacts();
+   }
+
+All three event classes share a common API:
+
+- ``getContacts()`` - Returns the array of contacts
+- ``removeContact(int $id)`` - Remove a single contact by ID
+- ``removeContacts(array $contacts)`` - Remove multiple contacts
+- ``getRemovedContacts()`` - Get the list of removed contacts
+
+.. vale off
+
+Campaign SMS events
+*******************
+
+.. vale on
+
+When integrating SMS with campaigns, use the batch campaign action event for better performance.
+
+.. vale off
+
+Batch action event
+==================
+
+.. vale on
+
+Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle campaign SMS actions.
+
+.. code-block:: php
+
+   <?php
+
+   use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
+   use Mautic\CampaignBundle\CampaignEvents;
+   use Mautic\SmsBundle\SmsEvents;
+   use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+   class CampaignSubscriber implements EventSubscriberInterface
+   {
+       public static function getSubscribedEvents(): array
+       {
+           return [
+               CampaignEvents::CAMPAIGN_ON_BUILD => ['onCampaignBuild', 0],
+           ];
+       }
+
+       public function onCampaignBuild(CampaignBuilderEvent $event): void
+       {
+           $event->addAction(
+               'my_plugin.send_sms',
+               [
+                   'label'          => 'Send Custom SMS',
+                   'batchEventName' => SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION,
+                   // Other configuration...
+               ]
+           );
+       }
+   }
+
+.. vale off
+
+Deprecation notice
+==================
+
+.. vale on
+
+.. deprecated:: 7.0
+
+   ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION`` is deprecated. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch contact processing.
+
+.. vale off
+
+SMS event constants
+*******************
+
+.. vale on
+
+The ``SmsEvents`` class defines all SMS-related event constants:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Event constant
+     - Description
+   * - ``ON_CAMPAIGN_TRIGGER_BATCH_ACTION``
+     - Fires when a campaign triggers an SMS action for a batch of contacts.
+   * - ``ON_CAMPAIGN_TRIGGER_ACTION``
+     - **Deprecated.** Legacy event for single-contact campaign SMS actions.
+   * - ``DNC_FILTER_CONTACTS_ON_SEND``
+     - Fires to filter contacts based on Do Not Contact status.
+   * - ``QUEUE_FILTER_CONTACTS_ON_SEND``
+     - Fires to filter contacts based on frequency rules.
+   * - ``FILTER_CONTACTS_ON_SEND``
+     - Fires for generic contact filtering before SMS dispatch.

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -68,7 +68,7 @@ Implement this interface to enable native batch SMS sending. Transports that onl
        public function sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection;
    }
 
-The ``RecipientCollection`` contains ``SmsRecipientDTO`` objects. After processing each recipient, call ``setResult(true)`` or ``setResult(false)`` on the Data Transfer Object (DTO) to indicate success or failure.
+The ``RecipientCollection`` contains ``SmsRecipientDTO`` objects. After processing each recipient, call ``setResult(true)`` or ``setResult(false)`` on the Data Transfer Object - DTO - to indicate success or failure.
 
 .. vale off
 

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -31,7 +31,7 @@ For the general Plugin layout, see the :doc:`Plugin structure</plugins/structure
 
 .. vale on
 
-The following worked example builds a transport inside a Plugin named ``HelloWorldBundle``. The transport-related files sit under the bundle's ``Sms/Transport`` directory::
+The worked example below builds a transport inside a Plugin named ``HelloWorldBundle``. The transport-related files sit under the bundle's ``Sms/Transport`` directory::
 
     plugins/HelloWorldBundle/
         Config/
@@ -130,7 +130,7 @@ Bulk sending and recipient data
 
 When a transport implements ``BulkTransportInterface``, Mautic passes a :xref:`RecipientCollection source` to ``sendBatchSms()``. The collection extends ``\ArrayIterator``, so you can iterate it directly, and each item is an :xref:`SmsRecipientDTO source`.
 
-Each Data Transfer Object (DTO) wraps one Contact together with its token data. The methods most relevant to a transport are:
+Each Data Transfer Object - DTO - wraps one Contact together with its token data. The methods most relevant to a transport are:
 
 .. vale off
 
@@ -235,9 +235,9 @@ Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle Campaign SMS actio
 Deprecation notice
 ==================
 
-.. deprecated:: 7.0
+.. important::
 
-   Mautic deprecates ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION``. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch Contact processing.
+   As of version 7.0, Mautic deprecates ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION``. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch Contact processing.
 
 SMS event constants
 *******************

--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -232,13 +232,6 @@ Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` to handle Campaign SMS actio
        );
    }
 
-Deprecation notice
-==================
-
-.. important::
-
-   As of version 7.0, Mautic deprecates ``SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION``. Use ``SmsEvents::ON_CAMPAIGN_TRIGGER_BATCH_ACTION`` instead for improved performance with batch Contact processing.
-
 SMS event constants
 *******************
 
@@ -255,7 +248,7 @@ The :xref:`SmsEvents source` class defines all SMS-related event constants:
    * - ``ON_CAMPAIGN_TRIGGER_BATCH_ACTION``
      - Fires when a Campaign triggers an SMS action for a batch of Contacts.
    * - ``ON_CAMPAIGN_TRIGGER_ACTION``
-     - **Deprecated.** Legacy event for single-Contact Campaign SMS actions.
+     - Fires when a Campaign triggers an SMS action for a single Contact.
    * - ``DNC_FILTER_CONTACTS_ON_SEND``
      - Fires to filter Contacts based on **Do Not Contact** status.
    * - ``QUEUE_FILTER_CONTACTS_ON_SEND``


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/e1d6a4d1-1f36-49fd-a8f9-f69e1aa586db)

Document the new SMS transport interfaces (TransportInterface, BulkTransportInterface, MMSTransportInterface), contact filtering events, batch campaign actions, and recipient data structures introduced in mautic/mautic#15999. Verified against merged PR state.

**Trigger Events**
- [mautic/mautic PR #15999: MMS and token support](https://github.com/mautic/mautic/pull/15999)
- [mautic/mautic PR #15999: MMS and token support](https://github.com/mautic/mautic/pull/15999)

---

_Tip: Point @Promptless at some of your docs debt and have it clean them up in the background 🧹_