### PR TITLE
Document form style-only Theme import requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ sphinx_rtd_theme==3.1.0
 readthedocs-sphinx-search==0.3.2
 rstcheck==6.3.0
 myst-parser==5.1.0
-linkify-it-py==2.1.1
+linkify-it-py==2.2.0
 esbonio==2.1.0
 attrs==26.1.0
 sphinxcontrib-phpdomain==0.15.2

--- a/docs/rest_api/themes.rst
+++ b/docs/rest_api/themes.rst
@@ -267,8 +267,12 @@ The API returns error messages if:
 
 * The request includes no uploaded file
 * The uploaded file doesn't have a ``.zip`` extension
-* The ZIP file is missing required files - ``config.json`` and ``html/message.html.twig`` (exception: form style-only themes that declare the ``form`` feature and include ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig`` don't require ``html/message.html.twig``)
+* The ZIP file is missing required files - ``config.json`` and ``html/message.html.twig``
 * The ZIP file contains disallowed file extensions
+
+.. note::
+
+   **Form style-only Themes:** A Theme that declares the ``form`` feature and includes a Form style override file - ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig`` - doesn't require ``html/message.html.twig``.
 
 .. vale off
 

--- a/docs/rest_api/themes.rst
+++ b/docs/rest_api/themes.rst
@@ -272,7 +272,11 @@ The API returns error messages if:
 
 .. note::
 
-   **Form style-only Themes:** A Theme that declares the ``form`` feature and includes a Form style override file - ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig`` - doesn't require ``html/message.html.twig``.
+   .. vale off
+
+   **Form style-only Themes:** A Theme that declares the ``form`` feature and includes a Form style override file such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig`` doesn't require ``html/message.html.twig``.
+
+   .. vale on
 
 .. vale off
 

--- a/docs/rest_api/themes.rst
+++ b/docs/rest_api/themes.rst
@@ -274,7 +274,7 @@ The API returns error messages if:
 
    .. vale off
 
-   **Form style-only Themes:** A Theme that declares the ``form`` feature and includes a Form style override file such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig`` doesn't require ``html/message.html.twig``.
+   **Form style-only Themes:** A Theme that declares only the ``form`` feature and includes a Form style override file such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig`` doesn't require ``html/message.html.twig``. This exception applies only when ``form`` is the Theme's sole feature; a Theme that also declares features such as ``email`` or ``page`` must still include the required files for each one.
 
    .. vale on
 

--- a/docs/rest_api/themes.rst
+++ b/docs/rest_api/themes.rst
@@ -267,7 +267,7 @@ The API returns error messages if:
 
 * The request includes no uploaded file
 * The uploaded file doesn't have a ``.zip`` extension
-* The ZIP file is missing required files - ``config.json`` and ``html/message.html.twig``
+* The ZIP file is missing required files - ``config.json`` and ``html/message.html.twig`` (exception: form style-only themes that declare the ``form`` feature and include ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig`` don't require ``html/message.html.twig``)
 * The ZIP file contains disallowed file extensions
 
 .. vale off

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -83,7 +83,11 @@ The configuration file tells Mautic how to utilize the Theme.
     ``page`` The Theme is compatible with the Page Builder. See :ref:`themes/getting_started:html/page.html.twig`.
 
     A corresponding ``html/[feature].html.twig`` file is required for each feature supported. For example, if the Theme supports ``email``, then there should be a ``html/email.html.twig`` file. See :ref:`themes/getting_started:Twig files` more information on each feature.
-builder
+
+    .. note::
+        **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file (``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``), ``html/form.html.twig`` and ``html/message.html.twig`` aren't required. This lets you create lightweight Themes that only customize Form styling without full template files. See :ref:`themes/forms:Customizing Forms` for more on Form style overrides.
+
+**builder**
     This contains an array of strings declaring which Builder the Theme supports. This currently only applies to Themes that support ``page`` or ``email``. By default, Themes without this line are only recognized by Mautic's Legacy Builder. New Themes built should declare the specific Builders it supports.
 
 Twig files

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -74,11 +74,11 @@ The configuration file tells Mautic how to utilize the Theme.
 
     .. vale off
 
-    * ``email`` - The Theme is compatible with the Email Builder. See :ref:`themes/getting_started:html/email.html.twig`.
-    * ``form`` - The Theme is compatible with customizing Forms. See :ref:`themes/getting_started:html/form.html.twig`.
-    * ``page`` - The Theme is compatible with the Page Builder. See :ref:`themes/getting_started:html/page.html.twig`.
+    * ``email`` - The Theme is compatible with the Email Builder. See :ref:`html/email.html.twig`.
+    * ``form`` - The Theme is compatible with customizing Forms. See :ref:`html/form.html.twig`.
+    * ``page`` - The Theme is compatible with the Page Builder. See :ref:`html/page.html.twig`.
 
-    You must have a corresponding ``html/[feature].html.twig`` file for each feature supported. For example, if the Theme supports ``email``, then there must be a ``html/email.html.twig`` file. See :ref:`themes/getting_started:Twig files` for more information on each feature.
+    You must have a corresponding ``html/[feature].html.twig`` file for each feature supported. For example, if the Theme supports ``email``, then there must be a ``html/email.html.twig`` file. See :ref:`Twig files` for more information on each feature.
 
     .. vale on
 
@@ -86,12 +86,14 @@ The configuration file tells Mautic how to utilize the Theme.
 
        .. vale off
 
-       **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``, it doesn't require ``html/form.html.twig`` and ``html/message.html.twig``. This lets you create lightweight Themes that only customize Form styling without full template files. See :ref:`themes/forms:Customizing Forms` for more on Form style overrides.
+       **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``, it doesn't require ``html/form.html.twig`` and ``html/message.html.twig``. This lets you create lightweight Themes that only customize Form styling without full template files. See :doc:`/themes/forms` for more on Form style overrides.
 
        .. vale on
 
 **builder**
     This contains an array of strings declaring which Builder the Theme supports. This currently only applies to Themes that support ``page`` or ``email``. By default, Themes without this line are only recognized by Mautic's Legacy Builder. New Themes built should declare the specific Builders it supports.
+
+.. _Twig files:
 
 Twig files
 ==========
@@ -124,6 +126,8 @@ It requires echoing two variables: ``message`` and ``content``.
             </div>
         </body>
     </html>
+
+.. _html/email.html.twig:
 
 ``html/email.html.twig``
 ------------------------
@@ -169,6 +173,8 @@ The GrapesJS Builder supports the :xref:`MJML email framework`.
       </mj-body>
     </mjml>
 
+.. _html/page.html.twig:
+
 ``html/page.html.twig``
 -----------------------
 
@@ -192,6 +198,8 @@ This file defines the base template when creating a new Landing Page and can con
         </body>
     </html>
 
+
+.. _html/form.html.twig:
 
 ``html/form.html.twig``
 -----------------------

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -86,7 +86,7 @@ The configuration file tells Mautic how to utilize the Theme.
 
        .. vale off
 
-       **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``, it doesn't require ``html/form.html.twig`` and ``html/message.html.twig``. This lets you create lightweight Themes that only customize Form styling without full template files. See :doc:`/themes/forms` for more on Form style overrides.
+       **Form style-only Themes:** A Theme that declares only the ``form`` feature and includes a Form style override file, such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``, doesn't need ``html/form.html.twig`` or ``html/message.html.twig``. This lets you create lightweight Themes that only customize Form styling. The exception applies only when ``form`` is the Theme's sole feature. If the Theme also declares other features, such as ``email`` or ``page``, it must still include the usual template files for each one. See :doc:`/themes/forms` for more on Form style overrides.
 
        .. vale on
 

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -85,7 +85,8 @@ The configuration file tells Mautic how to utilize the Theme.
     A corresponding ``html/[feature].html.twig`` file is required for each feature supported. For example, if the Theme supports ``email``, then there should be a ``html/email.html.twig`` file. See :ref:`themes/getting_started:Twig files` more information on each feature.
 
     .. note::
-        **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file (``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``), ``html/form.html.twig`` and ``html/message.html.twig`` aren't required. This lets you create lightweight Themes that only customize Form styling without full template files. See :ref:`themes/forms:Customizing Forms` for more on Form style overrides.
+
+       **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file (``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``), ``html/form.html.twig`` and ``html/message.html.twig`` aren't required. This lets you create lightweight Themes that only customize Form styling without full template files. See :ref:`themes/forms:Customizing Forms` for more on Form style overrides.
 
 **builder**
     This contains an array of strings declaring which Builder the Theme supports. This currently only applies to Themes that support ``page`` or ``email``. By default, Themes without this line are only recognized by Mautic's Legacy Builder. New Themes built should declare the specific Builders it supports.

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -72,21 +72,23 @@ The configuration file tells Mautic how to utilize the Theme.
 **features**
     An array of strings that tells Mautic which features the Theme supports. Currently recognized values are:
 
-    ``email`` The Theme is compatible with the Email Builder. See :ref:`themes/getting_started:html/email.html.twig`.
+    .. vale off
 
-.. vale off
+    * ``email`` - The Theme is compatible with the Email Builder. See :ref:`themes/getting_started:html/email.html.twig`.
+    * ``form`` - The Theme is compatible with customizing Forms. See :ref:`themes/getting_started:html/form.html.twig`.
+    * ``page`` - The Theme is compatible with the Page Builder. See :ref:`themes/getting_started:html/page.html.twig`.
 
-    ``form`` The Theme is compatible with the customizing Forms. See :ref:`themes/getting_started:html/form.html.twig`.
+    You must have a corresponding ``html/[feature].html.twig`` file for each feature supported. For example, if the Theme supports ``email``, then there must be a ``html/email.html.twig`` file. See :ref:`themes/getting_started:Twig files` for more information on each feature.
 
-.. vale on
-
-    ``page`` The Theme is compatible with the Page Builder. See :ref:`themes/getting_started:html/page.html.twig`.
-
-    A corresponding ``html/[feature].html.twig`` file is required for each feature supported. For example, if the Theme supports ``email``, then there should be a ``html/email.html.twig`` file. See :ref:`themes/getting_started:Twig files` more information on each feature.
+    .. vale on
 
     .. note::
 
-       **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file (``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``), ``html/form.html.twig`` and ``html/message.html.twig`` aren't required. This lets you create lightweight Themes that only customize Form styling without full template files. See :ref:`themes/forms:Customizing Forms` for more on Form style overrides.
+       .. vale off
+
+       **Form style-only Themes:** If a Theme declares the ``form`` feature and includes a Form style override file such as ``html/MauticFormBundle/Builder/_style.html.twig`` or ``html/MauticFormBundle/Builder/style.html.twig``, it doesn't require ``html/form.html.twig`` and ``html/message.html.twig``. This lets you create lightweight Themes that only customize Form styling without full template files. See :ref:`themes/forms:Customizing Forms` for more on Form style overrides.
+
+       .. vale on
 
 **builder**
     This contains an array of strings declaring which Builder the Theme supports. This currently only applies to Themes that support ``page`` or ``email``. By default, Themes without this line are only recognized by Mautic's Legacy Builder. New Themes built should declare the specific Builders it supports.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/fb6062b1-6b7b-4cc1-99d1-8a085d8323ae)

Updates Theme documentation to explain that Themes declaring the form feature and including a form style override file don't require html/message.html.twig or html/form.html.twig.

**Trigger Events**
- [mautic/mautic PR #16257: fix: allow importing style-only form themes](https://github.com/mautic/mautic/pull/16257)

---

_Tip: Use Slack message actions (⋯ menu → Update Docs) to capture doc updates without interrupting conversations 💬_