### PR TITLE
Document redirect_uri_mismatch OAuth error response

### DIFF
--- a/docs/rest_api/getting_started.rst
+++ b/docs/rest_api/getting_started.rst
@@ -19,6 +19,24 @@ If there's an OAuth error, you should see a JSON-encoded array similar to:
       "error_description": "The access token provided has expired."
    }
 
+Redirect URI mismatch error
+===========================
+
+If the ``redirect_uri`` parameter in your authorization request doesn't match the Redirect URI configured in your API credential, Mautic returns an ``HTTP 400 Bad Request`` response with an error message:
+
+.. code-block:: JSON
+
+   {
+      "error": "redirect_uri_mismatch",
+      "error_description": "The OAuth redirect URI does not match the API credentials configuration.",
+      "action": "Change it in the settings."
+   }
+
+To fix this error, make sure the ``redirect_uri`` query parameter in your ``/oauth/v2/authorize`` request exactly matches the Redirect URI you configured when creating the API credential in Mautic's API settings.
+
+System errors
+=============
+
 If a system error occurs, you should see a JSON-encoded array similar to the example below:
 
 .. code-block:: JSON


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/b1124514-0e93-48f1-b54d-b55a4a10ea41)

Documents the new structured error response for OAuth redirect_uri_mismatch errors, helping developers troubleshoot when their redirect URI doesn't match the API credential configuration.

**Trigger Events**
- [mautic/mautic PR #16260: fix(api): return 400 JSON instead of 500 for OAuth redirect_uri_mismatch](https://github.com/mautic/mautic/pull/16260)

---

_Tip: Add or adjust Promptless's style guide in [Agent Knowledge Base](https://app.gopromptless.ai/configure/settings) ✍️_