### PR TITLE
Document unique stage weight requirement in Stages REST API

### DIFF
--- a/docs/rest_api/stages.rst
+++ b/docs/rest_api/stages.rst
@@ -298,7 +298,7 @@ POST parameters
        Stage name
    * - ``weight``
      - integer
-     - Stage weight
+     - Stage weight. Each Stage must have a unique weight. The request fails with ``400 Bad Request`` when the weight matches another Stage.
    * - ``description``
      - string
      - Description of the Stage
@@ -319,6 +319,7 @@ Response
 ========
 
 * Returns ``201 Created`` when the request successfully creates a Stage.
+* Returns ``400 Bad Request`` with the message ``weight: Another stage with this weight already exists.`` when the ``weight`` matches another Stage.
 
 The response is a JSON object similar to :ref:`Get Stage <get Stage response>`.
 
@@ -376,6 +377,7 @@ Response
 
 * ``PUT``: returns ``200 OK`` when the request successfully updates the Stage or ``201 Created`` when the request creates a Stage.
 * ``PATCH``: returns ``200 OK`` when the request successfully updates the Stage or ``404 Not Found`` when the ID doesn't exist.
+* Either method returns ``400 Bad Request`` with the message ``weight: Another stage with this weight already exists.`` when the ``weight`` matches another Stage.
 
 The response is a JSON object similar to :ref:`Get Stage <get Stage response>`.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/97be2b60-1c89-42db-a022-f15e38310149)

Notes in the Stages REST API docs that each Stage must have a unique weight, and that creating or editing a Stage with a duplicate weight returns 400 Bad Request ("weight: Another stage with this weight already exists."). Surfaced by mautic/api-library PR #348; the validation itself was added in mautic/mautic PR #15404.

**Trigger Events**
- [mautic/api-library PR #348: Stage weight must be unique to pass the validation](https://github.com/mautic/api-library/pull/348)

---

_Tip: Point @Promptless at some of your docs debt and have it clean them up in the background 🧹_