### PR TITLE
Clarify campaign publishUp/publishDown values can be round-tripped on edit

### DIFF
--- a/docs/rest_api/campaigns.rst
+++ b/docs/rest_api/campaigns.rst
@@ -502,6 +502,10 @@ Edit a new Campaign. Note that this supports PUT or PATCH depending on the desir
 **PUT** creates a Campaign if the given ID doesn't exist and clears all the Campaign information, adds the information from the request.
 **PATCH** fails if the Campaign with the given ID doesn't exist and updates the Campaign field values with the values from the request.
 
+.. note::
+
+   The ``publishUp`` and ``publishDown`` fields accept the same ISO 8601 datetime values the API returns when you fetch a Campaign. When editing a Campaign, you can send these values back unchanged from a Get Campaign response - there's no need to reformat them.
+
 .. vale off
 
 **HTTP Request**


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/f1975228-08e6-43df-a917-a9d90e50ee1f)

Documents that the ISO 8601 publishUp/publishDown values returned by the campaign REST API are now accepted unchanged when editing a campaign (PATCH/PUT), reflecting the bug fix in mautic/mautic PR #16264.

**Trigger Events**
- [mautic/mautic PR #16264: Fixing publish dates for API](https://github.com/mautic/mautic/pull/16264)

---

_Tip: Assign suggestions to team members in the [Promptless dashboard](https://app.gopromptless.ai) to claim work 👥_