### PR TITLE
Document Field Groups REST API and FIELD_GROUP_LIST_ON_GENERATE event

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -232,6 +232,7 @@ There are several ways to support Mautic other than contributing with code.
    rest_api/dynamic_content
    rest_api/emails
    rest_api/fields
+   rest_api/field_groups
    rest_api/files
    rest_api/focus
    rest_api/forms

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -499,8 +499,12 @@ To leverage this, accept the array from ``$event->getQueryOptions()`` in the rep
       - callback
       - Callback to custom parse a result. This is optional and mainly used to handle a column result when all results are already looped over for ``$serializedColumns`` and $dateTimeColumns.
 
+.. vale off
+
 Customizing Custom Field Groups
 ******************************
+
+.. vale on
 
 Mautic organizes Contact and Company Custom Fields into groups, which appear as tabs on the Contact and Company view and edit pages. Beyond the built-in groups, admins can create their own Custom Field Groups under :guilabel:`Settings → Custom Field Groups`.
 

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -498,3 +498,69 @@ To leverage this, accept the array from ``$event->getQueryOptions()`` in the rep
       - Optional
       - callback
       - Callback to custom parse a result. This is optional and mainly used to handle a column result when all results are already looped over for ``$serializedColumns`` and $dateTimeColumns.
+
+Customizing Custom Field Groups
+******************************
+
+Mautic organizes Contact and Company Custom Fields into groups, which appear as tabs on the Contact and Company view and edit pages. Beyond the built-in groups, admins can create their own Custom Field Groups under :guilabel:`Settings → Custom Field Groups`.
+
+As Mautic builds the group list for a view, it dispatches the ``LeadEvents::FIELD_GROUP_LIST_ON_GENERATE`` event. Listen to this event to add your own groups or rename an existing group. Mautic resolves each group's display name through this event, so a Plugin can label custom groups without registering static translation keys.
+
+The event listener receives a ``Mautic\LeadBundle\Event\FieldGroupListEvent`` object. The groups are an associative array keyed by group alias, with the translated display name as the value.
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/FieldGroupSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\LeadBundle\Event\FieldGroupListEvent;
+    use Mautic\LeadBundle\LeadEvents;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\Contracts\Translation\TranslatorInterface;
+
+    final class FieldGroupSubscriber implements EventSubscriberInterface
+    {
+        public function __construct(private TranslatorInterface $translator)
+        {
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                LeadEvents::FIELD_GROUP_LIST_ON_GENERATE => ['onFieldGroupGenerate', 0],
+            ];
+        }
+
+        public function onFieldGroupGenerate(FieldGroupListEvent $event): void
+        {
+            // Only act on Contact (lead) field groups.
+            if ('lead' !== $event->getObject()) {
+                return;
+            }
+
+            $groups = $event->getGroups();
+
+            // Add a new group, keyed by its alias.
+            $groups['loyalty'] = $this->translator->trans('mautic.hello.world.field_group.loyalty');
+
+            $event->setGroups($groups);
+        }
+    }
+
+The ``FieldGroupListEvent`` provides the following methods:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Method
+     - Description
+   * - ``getGroups()``
+     - Returns the current groups as an ``[alias => displayName]`` array.
+   * - ``setGroups(array $groups)``
+     - Replaces the group list. Use this to add groups or override display names.
+   * - ``getObject()``
+     - Returns the object the list applies to, either ``'lead'`` or ``'company'``.

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -506,7 +506,7 @@ Customizing Custom Field Groups
 
 .. vale on
 
-Mautic organizes Contact and Company Custom Fields into groups, which appear as tabs on the Contact and Company view and edit pages. Beyond the built-in groups, admins can create their own Custom Field Groups under :guilabel:`Settings → Custom Field Groups`.
+Mautic organizes Contact and Company Custom Fields into groups, which appear as tabs on the Contact and Company view and edit pages. Beyond the built-in groups, admins can create their own Custom Field Groups under **Settings** > **Custom Field Groups**.
 
 As Mautic builds the group list for a view, it dispatches the ``LeadEvents::FIELD_GROUP_LIST_ON_GENERATE`` event. Listen to this event to add your own groups or rename an existing group. Mautic resolves each group's display name through this event, so a Plugin can label custom groups without registering static translation keys.
 

--- a/docs/plugin_extensions/contacts.rst
+++ b/docs/plugin_extensions/contacts.rst
@@ -506,7 +506,11 @@ Customizing Custom Field Groups
 
 .. vale on
 
+.. vale off
+
 Mautic organizes Contact and Company Custom Fields into groups, which appear as tabs on the Contact and Company view and edit pages. Beyond the built-in groups, admins can create their own Custom Field Groups under **Settings** > **Custom Field Groups**.
+
+.. vale on
 
 As Mautic builds the group list for a view, it dispatches the ``LeadEvents::FIELD_GROUP_LIST_ON_GENERATE`` event. Listen to this event to add your own groups or rename an existing group. Mautic resolves each group's display name through this event, so a Plugin can label custom groups without registering static translation keys.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ sphinx_rtd_theme==3.1.0
 readthedocs-sphinx-search==0.3.2
 rstcheck==6.3.0
 myst-parser==5.1.0
-linkify-it-py==2.1.1
+linkify-it-py==2.2.0
 esbonio==2.1.0
 attrs==26.1.0
 sphinxcontrib-phpdomain==0.15.2

--- a/docs/rest_api/field_groups.rst
+++ b/docs/rest_api/field_groups.rst
@@ -1,0 +1,313 @@
+Field Groups
+############
+
+Use this endpoint to manage Custom Field Groups in Mautic. Custom Field Groups organize Contact and Company Custom Fields into named tabs, alongside the built-in groups such as 'core', 'social', 'personal', and 'professional'.
+
+.. code-block:: php
+
+   <?php
+   use Mautic\MauticApi;
+   use Mautic\Auth\ApiAuth;
+
+   // ...
+   $initAuth = new ApiAuth();
+   $auth     = $initAuth->newAuth($settings);
+   $apiUrl   = "https://your-mautic.com";
+   $api      = new MauticApi();
+   $fieldGroupApi = $api->newApi("fieldGroups", $auth, $apiUrl);
+
+.. note::
+
+   Mautic generates a group's ``alias`` from its ``name`` when you create the group, and the alias never changes after that. The API ignores any ``alias`` you send in a create or edit payload. This keeps Contact and Company Fields that reference a group by alias from being orphaned when you rename the group.
+
+Get Field Group
+***************
+
+.. code-block:: php
+
+   <?php
+
+   //...
+   $fieldGroup = $fieldGroupApi->get($id);
+
+.. code-block:: json
+
+   {
+     "fieldGroup": {
+       "id": 12,
+       "name": "Billing",
+       "alias": "billing",
+       "description": "Invoicing fields",
+       "order": 5
+     }
+   }
+
+Get an individual Field Group by ID.
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``GET /field-groups/ID``
+
+Response
+========
+
+``Expected Response Code: 200``
+
+When the ID doesn't exist, the endpoint returns an ``HTTP 404 (Not Found)`` response.
+
+See the JSON code example.
+
+Field Group properties
+======================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``id``
+     - int
+     - ID of the Field Group
+   * - ``name``
+     - string
+     - Field Group name
+   * - ``alias``
+     - string
+     - Unique, auto-generated alias used by Custom Fields to reference the group. Immutable after creation.
+   * - ``description``
+     - string/null
+     - Field Group description
+   * - ``order``
+     - int
+     - Position of the group in the tab order on Contact and Company views
+
+List Field Groups
+*****************
+
+.. code-block:: php
+
+   <?php
+
+   //...
+   $fieldGroups = $fieldGroupApi->getList($searchFilter, $start, $limit, $orderBy, $orderByDir, $publishedOnly, $minimal);
+
+.. code-block:: json
+
+   {
+     "total": 2,
+     "fieldGroups": [
+       {
+         "id": 12,
+         "name": "Billing",
+         "alias": "billing",
+         "description": "Invoicing fields",
+         "order": 5
+       },
+       {
+         "id": 13,
+         "name": "Logistics",
+         "alias": "logistics",
+         "description": null,
+         "order": 6
+       }
+     ]
+   }
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``GET /field-groups``
+
+Response
+========
+
+``Expected Response Code: 200``
+
+See the JSON code example.
+
+Properties
+==========
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``total``
+     - int
+     - Count of all Field Groups
+   * - ``id``
+     - int
+     - ID of the Field Group
+   * - ``name``
+     - string
+     - Field Group name
+   * - ``alias``
+     - string
+     - Unique, auto-generated alias used by Custom Fields to reference the group
+   * - ``description``
+     - string/null
+     - Field Group description
+   * - ``order``
+     - int
+     - Position of the group in the tab order on Contact and Company views
+
+Create Field Group
+******************
+
+.. code-block:: php
+
+   <?php
+
+   $data = [
+       'name'        => 'Billing',
+       'description' => 'Invoicing fields'
+   ];
+
+   $fieldGroup = $fieldGroupApi->create($data);
+
+Create a new Field Group. Mautic generates the ``alias`` from the ``name``, so you don't need to send one.
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``POST /field-groups/new``
+
+.. vale off
+
+POST parameters
+===============
+
+.. vale on
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``name``
+     - string
+     - Field Group name. This is the only required parameter, and can only contain letters, numbers, and spaces.
+   * - ``description``
+     - string/null
+     - Field Group description
+   * - ``order``
+     - int
+     - Optional position of the group in the tab order. Defaults to the end of the list when omitted.
+
+Response
+========
+
+``Expected Response Code: 201``
+
+When the ``name`` is missing, the endpoint returns a validation error response.
+
+Properties
+==========
+
+Same as `Get Field Group`_.
+
+Edit Field Group
+****************
+
+.. code-block:: php
+
+   <?php
+
+   $id   = 12;
+   $data = [
+       'name'        => 'Billing Updated',
+       'description' => 'Updated description'
+   ];
+
+   $fieldGroup = $fieldGroupApi->edit($id, $data);
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``PATCH /field-groups/ID/edit``
+
+The ``alias`` stays the same when you rename a group, and Mautic ignores any ``alias`` value in the payload.
+
+.. vale off
+
+POST parameters
+===============
+
+.. vale on
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``name``
+     - string
+     - Field Group name. Can only contain letters, numbers, and spaces.
+   * - ``description``
+     - string/null
+     - Field Group description
+   * - ``order``
+     - int
+     - Position of the group in the tab order on Contact and Company views
+
+Response
+========
+
+``Expected Response Code: 200``
+
+Properties
+==========
+
+Same as `Get Field Group`_.
+
+Delete Field Group
+******************
+
+.. code-block:: php
+
+   <?php
+
+   $fieldGroup = $fieldGroupApi->delete($id);
+
+Delete a Field Group.
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``DELETE /field-groups/ID/delete``
+
+Response
+========
+
+``Expected Response Code: 200``
+
+Properties
+==========
+
+Same as `Get Field Group`_.

--- a/docs/rest_api/field_groups.rst
+++ b/docs/rest_api/field_groups.rst
@@ -49,8 +49,12 @@ When the ID doesn't exist, the endpoint returns a ``404 Not Found`` error.
 
 .. _get Field Group properties:
 
+.. vale off
+
 Field Group properties
 ----------------------
+
+.. vale on
 
 .. list-table::
    :widths: 25 25 50

--- a/docs/rest_api/field_groups.rst
+++ b/docs/rest_api/field_groups.rst
@@ -3,22 +3,10 @@ Field Groups
 
 Use this endpoint to manage Custom Field Groups in Mautic. Custom Field Groups organize Contact and Company Custom Fields into named tabs, alongside the built-in groups such as 'core', 'social', 'personal', and 'professional'.
 
-.. code-block:: php
-
-   <?php
-   use Mautic\MauticApi;
-   use Mautic\Auth\ApiAuth;
-
-   // ...
-   $initAuth = new ApiAuth();
-   $auth     = $initAuth->newAuth($settings);
-   $apiUrl   = "https://your-mautic.com";
-   $api      = new MauticApi();
-   $fieldGroupApi = $api->newApi("fieldGroups", $auth, $apiUrl);
-
 .. note::
 
-   Mautic generates a group's ``alias`` from its ``name`` when you create the group, and the alias never changes after that. The API ignores any ``alias`` you send in a create or edit payload. This way, renaming a group never orphans the Contact and Company Fields that reference it by alias.
+   * The Mautic API Library doesn't support the Field Groups API yet, so use the http endpoints described in this document instead.
+   * Mautic generates a group's ``alias`` from its ``name`` when you create the group, and the alias never changes after that. The API ignores any ``alias`` you send in a create or edit payload. This way, renaming a group never orphans the Contact and Company Fields that reference it by alias.
 
 .. vale off
 
@@ -28,25 +16,6 @@ Get Field Group
 .. vale on
 
 Retrieves an individual Field Group.
-
-.. code-block:: php
-
-   <?php
-
-   //...
-   $fieldGroup = $fieldGroupApi->get($id);
-
-.. code-block:: json
-
-   {
-     "fieldGroup": {
-       "id": 12,
-       "name": "Billing",
-       "alias": "billing",
-       "description": "Invoicing fields",
-       "order": 5
-     }
-   }
 
 .. vale off
 
@@ -60,20 +29,31 @@ HTTP request
 Response
 ========
 
-``Expected Response Code: 200``
+* Returns ``200 OK`` when the request successfully retrieves the Field Group.
 
-When the ID doesn't exist, the endpoint returns an ``HTTP 404 (Not Found)`` response.
+When the ID doesn't exist, the endpoint returns a ``404 Not Found`` error.
 
-See the JSON code example.
+.. _get Field Group response:
 
-.. vale off
+.. code-block:: json
+
+   {
+       "fieldGroup": {
+           "id": 12,
+           "name": "Billing",
+           "alias": "billing",
+           "description": "Invoicing fields",
+           "order": 5
+       }
+   }
+
+.. _get Field Group properties:
 
 Field Group properties
-======================
-
-.. vale on
+----------------------
 
 .. list-table::
+   :widths: 25 25 50
    :header-rows: 1
 
    * - Name
@@ -87,9 +67,9 @@ Field Group properties
      - Field Group name
    * - ``alias``
      - string
-     - Unique, auto-generated alias used by Custom Fields to reference the group. Immutable after creation.
+     - Unique, auto-generated alias used by Custom Fields to reference the group. Immutable after creation
    * - ``description``
-     - string/null
+     - string or null
      - Field Group description
    * - ``order``
      - int
@@ -104,35 +84,6 @@ List Field Groups
 
 Retrieves a list of Field Groups.
 
-.. code-block:: php
-
-   <?php
-
-   //...
-   $fieldGroups = $fieldGroupApi->getList($searchFilter, $start, $limit, $orderBy, $orderByDir, $publishedOnly, $minimal);
-
-.. code-block:: json
-
-   {
-     "total": 2,
-     "fieldGroups": [
-       {
-         "id": 12,
-         "name": "Billing",
-         "alias": "billing",
-         "description": "Invoicing fields",
-         "order": 5
-       },
-       {
-         "id": 13,
-         "name": "Logistics",
-         "alias": "logistics",
-         "description": null,
-         "order": 6
-       }
-     ]
-   }
-
 .. vale off
 
 HTTP request
@@ -145,14 +96,35 @@ HTTP request
 Response
 ========
 
-``Expected Response Code: 200``
+* Returns ``200 OK`` when the request successfully retrieves the Field Groups list.
 
-See the JSON code example.
+.. code-block:: json
+
+   {
+       "total": 2,
+       "fieldGroups": [
+           {
+               "id": 12,
+               "name": "Billing",
+               "alias": "billing",
+               "description": "Invoicing fields",
+               "order": 5
+           },
+           {
+               "id": 13,
+               "name": "Logistics",
+               "alias": "logistics",
+               "description": null,
+               "order": 6
+           }
+       ]
+   }
 
 Properties
-==========
+----------
 
 .. list-table::
+   :widths: 25 25 50
    :header-rows: 1
 
    * - Name
@@ -160,22 +132,16 @@ Properties
      - Description
    * - ``total``
      - int
-     - Count of all Field Groups
-   * - ``id``
-     - int
-     - ID of the Field Group
-   * - ``name``
-     - string
-     - Field Group name
-   * - ``alias``
-     - string
-     - Unique, auto-generated alias used by Custom Fields to reference the group
-   * - ``description``
-     - string/null
-     - Field Group description
-   * - ``order``
-     - int
-     - Position of the group in the tab order on Contact and Company views
+     - Total count of Field Groups
+   * - ``fieldGroups``
+     - array
+     - Array of Field Groups
+
+.. vale off
+
+For the rest of the properties, refer to :ref:`Field Group properties <get Field Group properties>`.
+
+.. vale on
 
 .. vale off
 
@@ -186,16 +152,12 @@ Create Field Group
 
 Creates a new Field Group. Mautic generates the ``alias`` from the ``name``, so you don't need to send one.
 
-.. code-block:: php
+.. code-block:: json
 
-   <?php
-
-   $data = [
-       'name'        => 'Billing',
-       'description' => 'Invoicing fields'
-   ];
-
-   $fieldGroup = $fieldGroupApi->create($data);
+   {
+       "name": "Billing",
+       "description": "Invoicing fields"
+   }
 
 .. vale off
 
@@ -206,14 +168,13 @@ HTTP request
 
 ``POST /field-groups/new``
 
-.. vale off
+.. _create Field Group POST parameters:
 
 POST parameters
-===============
-
-.. vale on
+---------------
 
 .. list-table::
+   :widths: 25 25 50
    :header-rows: 1
 
    * - Name
@@ -221,25 +182,27 @@ POST parameters
      - Description
    * - ``name``
      - string
-     - Field Group name. This is the only required parameter, and can only contain letters, numbers, and spaces.
+     - **Required.**
+
+       Field Group name. Can only contain letters, numbers, and spaces
    * - ``description``
-     - string/null
+     - string or null
      - Field Group description
    * - ``order``
      - int
-     - Optional position of the group in the tab order. Defaults to the end of the list when omitted.
+     - Position of the group in the tab order. Defaults to the end of the list when omitted
 
 Response
 ========
 
-``Expected Response Code: 201``
+* Returns ``201 Created`` when the request successfully creates a Field Group.
 
 When the ``name`` is missing, the endpoint returns a validation error response.
 
 Properties
-==========
+----------
 
-Same as `Get Field Group`_.
+Refer to :ref:`Field Group properties <get Field Group properties>`.
 
 .. vale off
 
@@ -255,17 +218,12 @@ This operation supports ``PUT`` or ``PATCH`` depending on the desired behavior:
 * ``PUT``: **full replacement**. The request creates a new Field Group if the ID is missing. If the ID exists, the request clears all existing data and replaces it with the provided values.
 * ``PATCH``: **partial update**. The request only updates field values based on the request data. The request fails when the Field Group ID doesn't exist.
 
-.. code-block:: php
+.. code-block:: json
 
-   <?php
-
-   $id   = 12;
-   $data = [
-       'name'        => 'Billing Updated',
-       'description' => 'Updated description'
-   ];
-
-   $fieldGroup = $fieldGroupApi->edit($id, $data);
+   {
+       "name": "Billing Updated",
+       "description": "Updated description"
+   }
 
 The ``alias`` stays the same when you rename a group, and Mautic ignores any ``alias`` value in the payload.
 
@@ -276,42 +234,24 @@ HTTP request
 
 .. vale on
 
-* ``PUT /field-groups/ID/edit``: updates an existing Field Group or creates a new one when the ID doesn't exist.
+* ``PUT /field-groups/ID/edit``: updates an existing Field Group, or creates a new one when the ID doesn't exist.
 * ``PATCH /field-groups/ID/edit``: updates an existing Field Group. The request fails when the ID doesn't exist.
 
-.. vale off
-
 POST parameters
-===============
+---------------
 
-.. vale on
-
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - Type
-     - Description
-   * - ``name``
-     - string
-     - Field Group name. Can only contain letters, numbers, and spaces.
-   * - ``description``
-     - string/null
-     - Field Group description
-   * - ``order``
-     - int
-     - Position of the group in the tab order on Contact and Company views
+Accepts the same parameters as those described in :ref:`Create Field Group <create Field Group POST parameters>`. All parameters are optional.
 
 Response
 ========
 
-* ``PUT``: returns ``200 OK`` when the request successfully updates the Field Group or ``201 Created`` when the request creates a Field Group.
-* ``PATCH``: returns ``200 OK`` when the request successfully updates the Field Group or ``404 Not Found`` error when the Field Group ID doesn't exist.
+* ``PUT``: returns ``200 OK`` when the request successfully updates the Field Group, or ``201 Created`` when the request creates a Field Group.
+* ``PATCH``: returns ``200 OK`` when the request successfully updates the Field Group, or a ``404 Not Found`` error when the Field Group ID doesn't exist.
 
 Properties
-==========
+----------
 
-Same as `Get Field Group`_.
+Refer to :ref:`Field Group properties <get Field Group properties>`.
 
 .. vale off
 
@@ -321,12 +261,6 @@ Delete Field Group
 .. vale on
 
 Deletes a Field Group.
-
-.. code-block:: php
-
-   <?php
-
-   $fieldGroup = $fieldGroupApi->delete($id);
 
 .. vale off
 
@@ -340,9 +274,11 @@ HTTP request
 Response
 ========
 
-``Expected Response Code: 200``
+* Returns ``200 OK`` when the request successfully deletes the Field Group.
+
+The response is a JSON object containing the data of the deleted Field Group, similar to :ref:`Get Field Group <get Field Group response>`.
 
 Properties
-==========
+----------
 
-Same as `Get Field Group`_.
+Refer to :ref:`Field Group properties <get Field Group properties>`.

--- a/docs/rest_api/field_groups.rst
+++ b/docs/rest_api/field_groups.rst
@@ -18,10 +18,16 @@ Use this endpoint to manage Custom Field Groups in Mautic. Custom Field Groups o
 
 .. note::
 
-   Mautic generates a group's ``alias`` from its ``name`` when you create the group, and the alias never changes after that. The API ignores any ``alias`` you send in a create or edit payload. This keeps Contact and Company Fields that reference a group by alias from being orphaned when you rename the group.
+   Mautic generates a group's ``alias`` from its ``name`` when you create the group, and the alias never changes after that. The API ignores any ``alias`` you send in a create or edit payload. This way, renaming a group never orphans the Contact and Company Fields that reference it by alias.
+
+.. vale off
 
 Get Field Group
 ***************
+
+.. vale on
+
+Retrieves an individual Field Group.
 
 .. code-block:: php
 
@@ -42,8 +48,6 @@ Get Field Group
      }
    }
 
-Get an individual Field Group by ID.
-
 .. vale off
 
 HTTP request
@@ -62,8 +66,12 @@ When the ID doesn't exist, the endpoint returns an ``HTTP 404 (Not Found)`` resp
 
 See the JSON code example.
 
+.. vale off
+
 Field Group properties
 ======================
+
+.. vale on
 
 .. list-table::
    :header-rows: 1
@@ -87,8 +95,14 @@ Field Group properties
      - int
      - Position of the group in the tab order on Contact and Company views
 
+.. vale off
+
 List Field Groups
 *****************
+
+.. vale on
+
+Retrieves a list of Field Groups.
 
 .. code-block:: php
 
@@ -163,8 +177,14 @@ Properties
      - int
      - Position of the group in the tab order on Contact and Company views
 
+.. vale off
+
 Create Field Group
 ******************
+
+.. vale on
+
+Creates a new Field Group. Mautic generates the ``alias`` from the ``name``, so you don't need to send one.
 
 .. code-block:: php
 
@@ -176,8 +196,6 @@ Create Field Group
    ];
 
    $fieldGroup = $fieldGroupApi->create($data);
-
-Create a new Field Group. Mautic generates the ``alias`` from the ``name``, so you don't need to send one.
 
 .. vale off
 
@@ -223,8 +241,19 @@ Properties
 
 Same as `Get Field Group`_.
 
+.. vale off
+
 Edit Field Group
 ****************
+
+.. vale on
+
+Edits a Field Group.
+
+This operation supports ``PUT`` or ``PATCH`` depending on the desired behavior:
+
+* ``PUT``: **full replacement**. The request creates a new Field Group if the ID is missing. If the ID exists, the request clears all existing data and replaces it with the provided values.
+* ``PATCH``: **partial update**. The request only updates field values based on the request data. The request fails when the Field Group ID doesn't exist.
 
 .. code-block:: php
 
@@ -238,6 +267,8 @@ Edit Field Group
 
    $fieldGroup = $fieldGroupApi->edit($id, $data);
 
+The ``alias`` stays the same when you rename a group, and Mautic ignores any ``alias`` value in the payload.
+
 .. vale off
 
 HTTP request
@@ -245,9 +276,8 @@ HTTP request
 
 .. vale on
 
-``PATCH /field-groups/ID/edit``
-
-The ``alias`` stays the same when you rename a group, and Mautic ignores any ``alias`` value in the payload.
+* ``PUT /field-groups/ID/edit``: updates an existing Field Group or creates a new one when the ID doesn't exist.
+* ``PATCH /field-groups/ID/edit``: updates an existing Field Group. The request fails when the ID doesn't exist.
 
 .. vale off
 
@@ -275,23 +305,28 @@ POST parameters
 Response
 ========
 
-``Expected Response Code: 200``
+* ``PUT``: returns ``200 OK`` when the request successfully updates the Field Group or ``201 Created`` when the request creates a Field Group.
+* ``PATCH``: returns ``200 OK`` when the request successfully updates the Field Group or ``404 Not Found`` error when the Field Group ID doesn't exist.
 
 Properties
 ==========
 
 Same as `Get Field Group`_.
 
+.. vale off
+
 Delete Field Group
 ******************
+
+.. vale on
+
+Deletes a Field Group.
 
 .. code-block:: php
 
    <?php
 
    $fieldGroup = $fieldGroupApi->delete($id);
-
-Delete a Field Group.
 
 .. vale off
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/2f3ff7c5-5ea1-4bfc-b602-fedf77fbb41c)

Adds developer docs for the Custom Field Groups feature merged into core LeadBundle in mautic/mautic#16265: a new REST API reference page for the /field-groups CRUD endpoints, and a new section in the Contacts plugin-extensions page covering the FIELD_GROUP_LIST_ON_GENERATE event and FieldGroupListEvent. Targets the 7.2 branch (mautic/mautic 7.x).

**Trigger Events**
- [mautic/mautic PR #16265: Add Field Groups to the core](https://github.com/mautic/mautic/pull/16265)

---

_Tip: Configure how Promptless handles changelogs in [Agent Settings](https://app.gopromptless.ai/configure/settings) 📋_