### PR TITLE
docs: Document theme template sandbox restrictions (7.0)

### DIFF
--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -218,6 +218,13 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
         </body>
     </html>
 
+Template sandbox restrictions
+=============================
+
+Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment. The sandbox blocks certain functions and filters that could enable remote code execution, data leakage, or filesystem probing.
+
+If your Theme template uses a restricted function or filter, Mautic throws an exception such as ``SecurityNotAllowedFilterError`` or ``SecurityNotAllowedFunctionError``. Use alternative approaches that don't require the restricted operation.
+
 Thumbnails
 ==========
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/5ae5275f-484a-49e3-ab17-3a316e8ef0b7)

Backports the theme template sandbox documentation to branch 7.0. Documents that Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment that blocks potentially dangerous functions and filters. Faithful backport of the reviewed 5.x change in PR #518, per maintainer request.

---

_Tip: Point @Promptless at some of your docs debt and have it clean them up in the background 🧹_