### PR TITLE
docs: Document theme template sandbox restrictions (7.1)

### DIFF
--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -218,6 +218,13 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
         </body>
     </html>
 
+Template sandbox restrictions
+=============================
+
+Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment. The sandbox blocks certain functions and filters that could enable remote code execution, data leakage, or filesystem probing.
+
+If your Theme template uses a restricted function or filter, Mautic throws an exception such as ``SecurityNotAllowedFilterError`` or ``SecurityNotAllowedFunctionError``. Use alternative approaches that don't require the restricted operation.
+
 Thumbnails
 ==========
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/d66ce4c8-6712-46a1-90cc-462315e933b1)

Backports the theme template sandbox documentation to branch 7.1. Documents that Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment that blocks potentially dangerous functions and filters. Faithful backport of the reviewed 5.x change in PR #518, per maintainer request.

---

_Tip: Add or adjust Promptless's style guide in [Agent Knowledge Base](https://app.gopromptless.ai/configure/settings) ✍️_