### PR TITLE
Document theme template sandbox restrictions (6.0)

### DIFF
--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -218,6 +218,13 @@ See :ref:`themes/forms:Customizing forms` on how to customize Form fields.
         </body>
     </html>
 
+Template sandbox restrictions
+=============================
+
+Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment. The sandbox blocks certain functions and filters that could enable remote code execution, data leakage, or filesystem probing.
+
+If your Theme template uses a restricted function or filter, Mautic throws an exception such as ``SecurityNotAllowedFilterError`` or ``SecurityNotAllowedFunctionError``. Use alternative approaches that don't require the restricted operation.
+
 Thumbnails
 ==========
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/5ae8b218-f4f4-40a8-b1ad-0c5d4c164dee)

Backports the theme template sandbox documentation to branch 6.0. Documents that Mautic renders User-uploaded Theme templates in a restricted Twig sandbox environment that blocks potentially dangerous functions and filters. Faithful recreation of suggestion 902e3282 / PR #532 content on a fresh branch so Read the Docs CI fires, per maintainer request.

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_