### PR TITLE
Document rating Form Field type in REST API reference

### DIFF
--- a/docs/rest_api/forms.rst
+++ b/docs/rest_api/forms.rst
@@ -1431,6 +1431,9 @@ Mautic supports various Form Field types to collect and validate Contact data. E
    * - ``radiogrp``
      - Radio group
      - ``syncList``, ``optionlist`` - an object of ``list`` arrays, ``labelAttributes``
+   * - ``rating``
+     - Star rating field
+     - ``star_count`` - number of symbols a Contact can select, from 1 to 10, ``symbol`` - the character used for each rating symbol, ``star_color`` - hex color for selected symbols, ``base_color`` - hex color for unselected symbols
    * - ``country``
      - Country selection dropdown
      - ``placeholder``, ``multiple``


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/b23bbe16-7d60-4fb0-a8f3-032b0cf289df)

Adds the new `rating` star-rating field type and its properties (`star_count`, `symbol`, `star_color`, `base_color`) to the Form Field types reference table in the Forms REST API docs, reflecting mautic/mautic PR #15342.

**Trigger Events**
- [mautic/mautic PR #15342: \[UXUI-103\] Rating field (form builder)](https://github.com/mautic/mautic/pull/15342)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_