### PR TITLE
Document Send example Email REST API endpoint

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ sphinx_rtd_theme==3.1.0
 readthedocs-sphinx-search==0.3.2
 rstcheck==6.3.0
 myst-parser==5.1.0
-linkify-it-py==2.1.1
+linkify-it-py==2.2.0
 esbonio==2.1.0
 attrs==26.1.0
 sphinxcontrib-phpdomain==0.15.2

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -908,7 +908,7 @@ Parameters
      - Description
    * - ``recipients``
      - array
-     - **Required**. Array of email addresses to send the example to
+     - **Required**. Array of Email addresses to send the example to
    * - ``contactId``
      - integer
      - Fill tokens with this Contact's data instead of fake data

--- a/docs/rest_api/emails.rst
+++ b/docs/rest_api/emails.rst
@@ -685,6 +685,8 @@ Refer to :ref:`Email properties <get Email properties>`.
 
 .. vale off
 
+.. _send Email to Contact:
+
 Send Email to Contact
 *********************
 
@@ -769,6 +771,8 @@ Response
 
 .. vale off
 
+.. _send Email to Segment:
+
 Send Email to Segment
 *********************
 
@@ -841,6 +845,112 @@ Properties
    * - ``failedRecipients``
      - integer
      - Total number of Emails that failed to deliver
+
+.. vale off
+
+Send example Email
+******************
+
+.. vale on
+
+Sends a one-off proof copy of an Email to one or more arbitrary addresses. It's the API equivalent of the **Send example** action in the Email builder.
+
+Unlike :ref:`Send Email to Contact <send Email to Contact>` and :ref:`Send Email to Segment <send Email to Segment>`, this endpoint:
+
+.. vale off
+
+* Sends to arbitrary email addresses rather than Contacts, so Do Not Contact status doesn't apply.
+* Records no statistics. It tracks no opens or clicks and strips the tracking pixel.
+* Works on unpublished or draft Emails, since you proof them before they go live.
+* Never changes the stored Email. It prefixes the subject with ``[TEST]`` for the send and then restores the original, so the prefix is never saved.
+
+.. vale on
+
+By default, the endpoint fills tokens with fake Contact data. Pass ``contactId`` to fill them from a real Contact instead, or use the ``tokens`` parameter to override individual values.
+
+.. code-block:: php
+
+   <?php
+
+   $data = array(
+       'recipients' => array('proof@example.com'),
+   );
+
+   $response = $emailApi->makeRequest('emails/'.$emailId.'/example/send', $data, 'POST');
+
+.. vale off
+
+HTTP request
+============
+
+.. vale on
+
+``POST /emails/ID/example/send``
+
+.. vale off
+
+Permissions
+-----------
+
+.. vale on
+
+The authenticated User needs the ``email:emails:viewown`` or ``email:emails:viewother`` permission. Supplying ``contactId`` additionally requires the ``lead:leads:viewown`` or ``lead:leads:viewother`` permission.
+
+Parameters
+----------
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``recipients``
+     - array
+     - **Required**. Array of email addresses to send the example to
+   * - ``contactId``
+     - integer
+     - Fill tokens with this Contact's data instead of fake data
+   * - ``tokens``
+     - associative array
+     - Associative array of tokens to replace in the Email content, for example ``{"{custom}": "value"}``. The surrounding braces are optional
+   * - ``noSubjectPrefix``
+     - boolean
+     - Set to ``true`` to skip the ``[TEST]`` subject prefix. Defaults to ``false``
+
+Response
+========
+
+* Returns ``200 OK`` once the request runs. Check the ``errors`` array to confirm delivery: a recipient that fails appears there without failing the whole request.
+
+.. code-block:: json
+
+   {
+       "success": true,
+       "sent": ["proof@example.com"],
+       "errors": []
+   }
+
+Properties
+----------
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - ``success``
+     - boolean
+     - ``true`` when the endpoint reaches every recipient, leaving ``errors`` empty
+   * - ``sent``
+     - array
+     - Email addresses that received the example
+   * - ``errors``
+     - array
+     - Error messages for recipients that failed
 
 .. vale off
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/23042c19-daa6-4802-a83f-b29e6b7d0440)

Documents the new `POST /emails/ID/example/send` endpoint added in mautic/mautic#16308, the API equivalent of the Email builder's "Send example" proof action. Covers request body (`recipients`, `contactId`, `tokens`, `noSubjectPrefix`), permissions, the `{ success, sent, errors }` response, and how it differs from the existing send-to-contact and send-to-segment endpoints. Also adds cross-reference anchors to those two sections.

**Trigger Events**
- [mautic/mautic PR #16308: Send Email Example Api](https://github.com/mautic/mautic/pull/16308)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_