### PR TITLE
Replace stale Gitpod testing reference with GitHub Codespaces (7.2)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Supporting Mautic
 
 There are several ways to support Mautic other than contributing with code.
 
-1. Help with testing bugs and features using Gitpod in the browser - head to the :xref:`Mautic Tester Docs`
+1. Help with testing bugs and features using GitHub Codespaces in the browser - head to the :xref:`Mautic Tester Docs`
 2. Help with improving the documentation on this site, and the :xref:`Mautic End User Docs`.
 3. :xref:`Contribute to Mautic` with other skills
 4. Become a :xref:`Become a Member of Mautic`


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/5c63e172-ccf7-45b0-9529-e7579e3ff0cd)

mautic/mautic PR #16310 removes all Gitpod support code because Gitpod is deprecated/being sunset; the community has moved PR/instance testing to GitHub Codespaces. The developer docs landing page (docs/index.rst) still told contributors to test "using Gitpod in the browser". This updates that line to reference GitHub Codespaces, matching the current Mautic Tester Docs. Targets the 7.2 developer docs branch per the org branch-targeting table (source base 7.x → dev docs 7.2). Note: an existing 7.1-based suggestion (promptless/pr-16032-github-codespaces) already made the same fix on 7.1.

**Trigger Events**
- [mautic/mautic PR #16310: Removing Gitpod related code as the service is deprecated](https://github.com/mautic/mautic/pull/16310)

---

_Tip: Add more repositories in your [Configuration](https://app.gopromptless.ai/configuration) to keep multiple doc sites in sync 📚_