### PR TITLE
Replace stale Gitpod testing reference with GitHub Codespaces (6.0)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Supporting Mautic
 
 There are several ways to support Mautic other than contributing with code.
 
-1. Help with testing bugs and features using Gitpod in the browser - head to the :xref:`Mautic Tester Docs`
+1. Help with testing bugs and features using GitHub Codespaces in the browser - head to the :xref:`Mautic Tester Docs`
 2. Help with improving the documentation on this site, and the :xref:`Mautic End User Docs`.
 3. :xref:`Contribute to Mautic` with other skills
 4. Become a :xref:`Become a Member of Mautic`


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/dd4c583d-cc4c-4018-9890-db2efe9ac18a)

Updates the developer docs landing page (docs/index.rst) to reference GitHub Codespaces instead of the deprecated Gitpod for browser-based PR/instance testing, matching the current Mautic Tester Docs. Backport of PR #541 (7.2) to the 6.0 branch per maintainer @adiati98's request.

---

_Tip: Leave inline comments with `@Promptless` on suggestion diffs in the [Promptless dashboard](https://app.gopromptless.ai/suggestions) for targeted refinements 💬_