### PR TITLE
Type the custom permissions constructor param in extension examples

### DIFF
--- a/docs/plugin_services/security.rst
+++ b/docs/plugin_services/security.rst
@@ -125,7 +125,7 @@ It's possible to define your own custom permissions within your Plugin. Make sur
 
    class HelloWorldPermissions extends AbstractPermissions
    {
-       public function __construct($params)
+       public function __construct(array $params)
        {
            parent::__construct($params);
 

--- a/docs/plugins/permissions.rst
+++ b/docs/plugins/permissions.rst
@@ -122,7 +122,7 @@ A Plugin creates its own set of permissions by defining a Permission class. Each
 
    class HelloWorldPermissions extends AbstractPermissions
    {
-       public function __construct($params)
+       public function __construct(array $params)
        {
            parent::__construct($params);
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/86023176-11f9-4a54-a31c-57493d72314c)

Updates the `HelloWorldPermissions` extension examples in `docs/plugins/permissions.rst` and `docs/plugin_services/security.rst` to declare `public function __construct(array $params)`, matching the canonical `AbstractPermissions::__construct(array $params)` signature now used across mautic/mautic core (after `ParamTypeByParentCallTypeRector` was applied in PR #16349). Code-example-only change.

**Trigger Events**
- [mautic/mautic PR #16349: Type coverage: register ParamTypeByParentCallTypeRector](https://github.com/mautic/mautic/pull/16349)

---

_Tip: Tag @Promptless in a GitHub issue to turn it into a documentation update 🐙_