### PR TITLE
docs: Document ConnectionException for API library transport errors

### DIFF
--- a/docs/rest_api/getting_started.rst
+++ b/docs/rest_api/getting_started.rst
@@ -30,6 +30,28 @@ If a system error occurs, you should see a JSON-encoded array similar to the exa
       }
    }
 
+Handling connection errors with the API library
+------------------------------------------------
+
+The preceding JSON error responses only apply when Mautic receives your request and returns a response. If you're using the Mautic API library and the request can't reach Mautic at all - for example, the host doesn't resolve, the connection times out, or the secure handshake fails - the library throws a ``Mautic\Exception\ConnectionException`` instead. Its message names the target URL and the underlying transport error, so you can tell a connectivity problem apart from an error Mautic returns. For cURL-based clients, the message includes the original cURL error text.
+
+``ConnectionException`` extends the library's ``AbstractApiException``, which in turn extends PHP's ``\Exception``. Existing code that catches ``\Exception`` keeps working and simply receives a clearer message. To inspect the underlying transport failure, call ``getPrevious()`` on the caught exception to get the original client exception.
+
+.. code-block:: php
+
+   use Mautic\Exception\ConnectionException;
+
+   try {
+       $response = $contactApi->getList('', 0, 1);
+   } catch (ConnectionException $e) {
+       // The request never reached Mautic - for example, host unreachable or timeout.
+       // $e->getMessage() names the target URL and the transport error.
+       error_log($e->getMessage());
+
+       // Inspect the original PSR-18 client exception, if you need it:
+       $transportError = $e->getPrevious();
+   }
+
 Mautic version verification
 ***************************
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/369ccbdf-8fea-4576-93dc-8707610d854f)

Adds a "Handling connection errors with the API library" subsection to the REST API getting-started guide's Error handling section. It documents the new Mautic\Exception\ConnectionException (api-library PR #349) thrown when a request can't reach Mautic (host unresolved, connection timeout, TLS handshake failure), its message format, the AbstractApiException/\Exception hierarchy and backward compatibility, and retrieving the underlying transport exception via getPrevious(), with a PHP catch example.

**Trigger Events**
- [mautic/api-library PR #349: Surface transport errors from the HTTP client (fixes #184)](https://github.com/mautic/api-library/pull/349)

---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_