### PR TITLE
docs: Document GrapesJS Builder asset build workflow

### DIFF
--- a/docs/themes/grapesjs.rst
+++ b/docs/themes/grapesjs.rst
@@ -174,14 +174,14 @@ You can download a :xref:`GrapesJS Demo Plugin` to get you started.
 Building the Builder assets
 ***************************
 
-From Mautic 7, Mautic no longer commits the GrapesJS Builder's compiled JavaScript and CSS to the repository. The build output lives in the Plugin's ``Assets/library/js/dist/`` directory, which ``.gitignore`` now excludes, and Mautic generates it at build time instead - the same way it handles other compiled assets such as ``media/css`` and ``media/js``.
+From Mautic 7.2, Mautic no longer commits the GrapesJS Builder's compiled JavaScript and CSS to the repository. The build output lives in the Plugin's ``Assets/library/js/dist/`` directory, which ``.gitignore`` now excludes, and Mautic generates it at build time instead - the same way it handles other compiled assets such as ``media/css`` and ``media/js``.
 
 This matters when you work from a git checkout. After a fresh clone, the ``dist/`` directory doesn't exist yet, so the Builder can't load until you build the assets. Missing assets don't cause Mautic to fail. It logs a warning and skips loading the Builder scripts. Build them before you use the GrapesJS Builder.
 
 Building the assets requires Node, and Mautic builds them with Node 24. In most cases, you don't need to run the build by hand because Mautic builds the assets automatically at these points:
 
 * When you run ``composer install`` or ``composer update``. This step is non-fatal - if Node isn't available, Composer prints a warning and continues, so you can build the assets later.
-* When you start the DDEV environment, as part of the bootstrap.
+* When DDEV provisions the environment for the first time, not on every start, so for an existing environment, run ``ddev gjs-build`` to rebuild.
 
 To build or rebuild the assets manually with Composer, run:
 

--- a/docs/themes/grapesjs.rst
+++ b/docs/themes/grapesjs.rst
@@ -174,13 +174,11 @@ You can download a :xref:`GrapesJS Demo Plugin` to get you started.
 Building the Builder assets
 ***************************
 
-.. vale on
+From Mautic 7, Mautic no longer commits the GrapesJS Builder's compiled JavaScript and CSS to the repository. The build output lives in the Plugin's ``Assets/library/js/dist/`` directory, which ``.gitignore`` now excludes, and Mautic generates it at build time instead - the same way it handles other compiled assets such as ``media/css`` and ``media/js``.
 
-From Mautic 7, the GrapesJS Builder's compiled JavaScript and CSS aren't committed to the repository. The build output lives in the Plugin's ``Assets/library/js/dist/`` directory, which ``.gitignore`` now excludes, and Mautic generates it at build time instead - the same way it handles other compiled assets like ``media/css`` and ``media/js``.
+This matters when you work from a git checkout. After a fresh clone, the ``dist/`` directory doesn't exist yet, so the Builder can't load until you build the assets. Missing assets don't cause Mautic to fail. It logs a warning and skips loading the Builder scripts. Build them before you use the GrapesJS Builder.
 
-This matters when you work from a git checkout. After a fresh clone, the ``dist/`` directory doesn't exist yet, so the Builder can't load until you build the assets. Missing assets don't cause Mautic to fail: it logs a warning and skips loading the Builder scripts. Build them before you use the GrapesJS Builder.
-
-Building the assets requires Node, and Mautic builds them with Node 24. In most cases you don't need to run the build by hand, because Mautic builds the assets automatically at these points:
+Building the assets requires Node, and Mautic builds them with Node 24. In most cases, you don't need to run the build by hand because Mautic builds the assets automatically at these points:
 
 * When you run ``composer install`` or ``composer update``. This step is non-fatal - if Node isn't available, Composer prints a warning and continues, so you can build the assets later.
 * When you start the DDEV environment, as part of the bootstrap.
@@ -197,4 +195,6 @@ With DDEV, run:
 
     ddev gjs-build
 
-Both commands install the Plugin's ``npm`` dependencies if needed, then build the assets. Under the hood, the build uses Parcel, which content-hashes the output filenames - for example ``builder.4f2a.css`` - and writes a ``manifest.json`` that maps the logical asset names to the hashed files. At runtime, the Builder's ``AssetsSubscriber`` reads this manifest to resolve and inject the correct files.
+Both commands install the Plugin's ``npm`` dependencies if needed, then build the assets. Under the hood, the build uses Parcel, which content-hashes the output filenames - for example, ``builder.4f2a.css`` - and writes a ``manifest.json`` that maps the logical asset names to the hashed files. At runtime, the Builder's ``AssetsSubscriber`` reads this manifest to resolve and inject the correct files.
+
+.. vale on

--- a/docs/themes/grapesjs.rst
+++ b/docs/themes/grapesjs.rst
@@ -168,3 +168,33 @@ The resulting HTML source appears as follows:
   The Plugin code loads before ``builder.js`` which results in the data registering in the global window object.
 
 You can download a :xref:`GrapesJS Demo Plugin` to get you started.
+
+.. vale off
+
+Building the Builder assets
+***************************
+
+.. vale on
+
+From Mautic 7, the GrapesJS Builder's compiled JavaScript and CSS aren't committed to the repository. The build output lives in the Plugin's ``Assets/library/js/dist/`` directory, which ``.gitignore`` now excludes, and Mautic generates it at build time instead - the same way it handles other compiled assets like ``media/css`` and ``media/js``.
+
+This matters when you work from a git checkout. After a fresh clone, the ``dist/`` directory doesn't exist yet, so the Builder can't load until you build the assets. Missing assets don't cause Mautic to fail: it logs a warning and skips loading the Builder scripts. Build them before you use the GrapesJS Builder.
+
+Building the assets requires Node, and Mautic builds them with Node 24. In most cases you don't need to run the build by hand, because Mautic builds the assets automatically at these points:
+
+* When you run ``composer install`` or ``composer update``. This step is non-fatal - if Node isn't available, Composer prints a warning and continues, so you can build the assets later.
+* When you start the DDEV environment, as part of the bootstrap.
+
+To build or rebuild the assets manually with Composer, run:
+
+.. code-block:: bash
+
+    composer gjs-build
+
+With DDEV, run:
+
+.. code-block:: bash
+
+    ddev gjs-build
+
+Both commands install the Plugin's ``npm`` dependencies if needed, then build the assets. Under the hood, the build uses Parcel, which content-hashes the output filenames - for example ``builder.4f2a.css`` - and writes a ``manifest.json`` that maps the logical asset names to the hashed files. At runtime, the Builder's ``AssetsSubscriber`` reads this manifest to resolve and inject the correct files.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/ccec7cce-d161-4c2b-a31d-ce6df8e43521)

Documents that the GrapesJS Builder's compiled JS/CSS are no longer committed to git (mautic/mautic#16435). Adds a "Building the Builder assets" section to docs/themes/grapesjs.rst covering the gitignored dist/ directory, automatic builds on composer install/update and during initial DDEV provisioning (non-fatal when Node is missing), manual composer gjs-build / ddev gjs-build commands, the Node 24 build version, and how Parcel content-hashing plus manifest.json feed the runtime AssetsSubscriber.

**@patrykgruszka review (applied)**
- Version scope: changed "From Mautic 7" to "From Mautic 7.2" — the untracked-assets build workflow ships only in 7.2, not 7.0/7.1 (confirmed against source PR #16435: base 7.x / milestone 7.2.0 / release_metadata 7.2.0-rc; the gjs-build command and dist .gitignore line are absent on 7.0.2 and 7.1.3). Applied verbatim.
- DDEV trigger: corrected the bullet that claimed the build runs on every DDEV start. It now states the build runs when DDEV provisions the environment for the first time (not on every start), and directs existing environments to run `ddev gjs-build`. Applied with a minor wording refinement for parallel list structure and concision; the substance the reviewer requested is unchanged.

**Trigger Events**
- [mautic/mautic PR #16435: Stop tracking GrapesJS dist assets in git & Parcel update](https://github.com/mautic/mautic/pull/16435)

---

_Tip: Point @Promptless at some of your docs debt and have it clean them up in the background 🧹_