### PR TITLE
docs: Port "Helpers" page to 7.2

### DIFF
--- a/docs/plugin_miscellaneous/helpers.rst
+++ b/docs/plugin_miscellaneous/helpers.rst
@@ -13,16 +13,78 @@ Helpers
 
 .. vale on
 
+Mautic ships many helper classes. The most commonly used ones appear below.
+
 .. vale off
 
 ChartQuery and Graphs
 *********************
+
+.. vale on
+
+Several classes help generate chart data:
+
+.. code-block:: php
+
+    <?php
+
+    use Mautic\CoreBundle\Helper\Chart\ChartQuery;
+    use Mautic\CoreBundle\Helper\Chart\LineChart;
+
+    $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
+    $query = new ChartQuery($this->entityManager->getConnection(), $dateFrom, $dateTo);
+    $q     = $query->prepareTimeDataQuery('lead_points_change_log', 'date_added', $filter);
+    $data  = $query->loadAndBuildTimeData($q);
+    $chart->setDataset($this->translator->trans('mautic.point.changes'), $data);
+    $data  = $chart->render();
+
+``ChartQuery`` retrieves chart data from the database. Instantiate it with the Doctrine connection and the ``DateTime`` from and to dates. It guesses the time unit - hours, days, weeks, months, or years - from the range, or you can force a unit by passing it as the fourth argument - ``H``, ``d``, ``W``, ``m``, or ``Y``. It also fills in any missing items so the data displays correctly in a line chart.
+
+``LineChart`` displays date and time data with time on the horizontal axis and values on the vertical axis, and it can hold multiple datasets. Instantiate it with a unit - ``null`` to guess - a from date, a to date, and a date format - ``null`` to generate one automatically. Add a dataset with ``setDataset($label, $data)``, where ``$data`` comes from ``ChartQuery``. Mautic generates the color of each dataset automatically. Call ``render()`` to get the data prepared for the frontend.
+
+Instantiate ``PieChart`` with ``new PieChart()``. Add a dataset with ``setDataset($label, $value)``, then call ``render()``.
+
+``BarChart`` displays variants of the same value, with the variants on the horizontal axis. Instantiate it with ``new BarChart($labels)``, where ``$labels`` lists the variants. Add a dataset with ``setDataset($label, $data, $order)``, then call ``render()``.
+
+On the frontend, render the prepared chart template and pass in the chart data, the chart type - ``line``, ``bar``, or ``pie`` - and the chart height. The width is responsive.
+
+.. vale off
 
 DateTime
 ********
 
 .. vale on
 
+Use ``Mautic\CoreBundle\Helper\DateTimeHelper`` to convert between Coordinated Universal Time and the local timezone:
+
+.. code-block:: php
+
+    <?php
+
+    $dtHelper  = new \Mautic\CoreBundle\Helper\DateTimeHelper('2015-07-20 21:39:00', 'Y-m-d H:i:s', 'local');
+    $utcString = $dtHelper->toUtcString();
+
+Refer to the class for its other conversion methods.
+
+.. vale off
+
 Input
 *****
 
+.. vale on
+
+Use ``Mautic\CoreBundle\Helper\InputHelper`` to sanitize submitted input into clean strings:
+
+.. code-block:: php
+
+    <?php
+
+    use Mautic\CoreBundle\Helper\InputHelper;
+
+    // ...
+    $clean = InputHelper::clean($input);
+    $clean = InputHelper::int($input);
+    $clean = InputHelper::alphanum($input);
+    $clean = InputHelper::html($input);
+
+Refer to the class for its other cleaning methods.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/7aa7148b-5035-40a2-9bb3-2d4bc0897681)

Ports the legacy Helpers developer guide (ChartQuery/Graphs, DateTime, Input helper classes) into docs/plugin_miscellaneous/helpers.rst, converting the legacy Markdown to RST. Targets the 7.2 base branch per the team's plan to set content in 7.2 first, then cherry-pick to 7.1/7.0/6.0/5.x. Resolves docs issue #411 (parent #410).

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Tag @Promptless in GitHub PR comments to guide documentation changes during code review 🐙_