### PR TITLE
docs: Port "Flash messages" page to 7.2

### DIFF
--- a/docs/plugin_miscellaneous/flash_messages.rst
+++ b/docs/plugin_miscellaneous/flash_messages.rst
@@ -12,3 +12,60 @@ Flash messages
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+The ``Mautic\CoreBundle\Service\FlashBag`` service manages flash messages - the alerts Mautic shows after an action. It takes care of translation and message levels, and can optionally add a matching entry to the notification center.
+
+From a controller
+*****************
+
+.. vale off
+
+Controllers that extend one of :ref:`Mautic's common controllers<plugins/mvc:Controllers>` can use the ``addFlashMessage()`` helper:
+
+.. vale on
+
+.. code-block:: php
+
+    <?php
+
+    $this->addFlashMessage(
+        'mautic.translation.key',
+        ['%placeholder%' => 'some text'],
+        FlashBag::LEVEL_NOTICE, // Message level
+        'flashes'               // Translation domain
+    );
+
+From a service
+**************
+
+From a model or any other service, inject ``Mautic\CoreBundle\Service\FlashBag`` and call ``add()``:
+
+.. code-block:: php
+
+    <?php
+
+    use Mautic\CoreBundle\Service\FlashBag;
+
+    final class ExampleService
+    {
+        public function __construct(private FlashBag $flashBag)
+        {
+        }
+
+        public function notify(): void
+        {
+            $this->flashBag->add(
+                'mautic.translation.key',
+                ['%placeholder%' => 'some text'],
+                FlashBag::LEVEL_NOTICE,
+                'flashes'
+            );
+        }
+    }
+
+Both ``addFlashMessage()`` and ``FlashBag::add()`` take a final ``$addNotification`` argument. Set it to ``true`` to add a matching entry to the notification center alongside the flash message.
+
+Notifications
+*************
+
+Mautic also has a notification center. Adding a flash message doesn't create a notification by default, but you can opt in with the ``$addNotification`` flag described earlier, or add one on its own. To add a standalone notification, inject ``Mautic\CoreBundle\Model\NotificationModel`` and call its ``addNotification()`` method.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/34d1f45c-fee5-4144-8165-a1b78df07247)

Ports the legacy Flash messages developer guide into docs/plugin_miscellaneous/flash_messages.rst, converting the Markdown source to RST and updating it to the current 7.x FlashBag service API. Documents the controller addFlashMessage() helper, injecting FlashBag in services, the $addNotification flag, and NotificationModel for standalone notifications. Resolves porting issue #403 (source from parent #402), targeting the 7.2 base branch.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Adjust how proactive or focused Promptless is in [Agent Settings](https://app.gopromptless.ai/configure/settings) ⚙️_