### PR TITLE
docs: Port "Implementing variant - A/B test - support to entities" dev docs page

### DIFF
--- a/docs/plugin_miscellaneous/variant_entities.rst
+++ b/docs/plugin_miscellaneous/variant_entities.rst
@@ -12,3 +12,77 @@ Implementing variant - A/B test - support to entities
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Mautic provides helper methods for creating variants of an entity, which is especially useful for A/B testing. Use the interfaces and traits below to add variant support to your Plugin's entities.
+
+.. vale off
+
+VariantInterface
+****************
+
+.. vale on
+
+The ``\Mautic\CoreBundle\Entity\VariantInterface`` entity interface ensures an entity has everything Mautic needs to handle its variants correctly.
+
+.. vale off
+
+VariantEntityTrait
+******************
+
+.. vale on
+
+The ``\Mautic\CoreBundle\Entity\VariantEntityTrait`` trait provides the properties needed to define an entity's relationship to other items. In the entity's ``loadMetadata()`` method, call ``$this->addVariantMetadata()``.
+
+.. vale off
+
+VariantModelTrait
+*****************
+
+.. vale on
+
+The ``\Mautic\CoreBundle\VariantModelTrait`` trait provides the ``preVariantSaveEntity()``, ``postVariantSaveEntity()``, and ``convertVariant()`` methods. Call ``preVariantSaveEntity()`` before ``saveEntity()``, then call ``postVariantSaveEntity()`` afterwards, as in the following example:
+
+.. code-block:: php
+
+   <?php
+   // plugins/HelloWorldBundle/Model/WorldModel.php
+
+   // Reset A/B test if applicable
+   $variantStartDate = new \DateTime();
+   // setVariantHits is the stat tracker property for this variant
+   $resetVariants    = $this->preVariantSaveEntity($entity, ['setVariantHits'], $variantStartDate);
+
+   parent::saveEntity($entity, $unlock);
+
+   $this->postVariantSaveEntity($entity, $resetVariants, $entity->getRelatedEntityIds(), $variantStartDate);
+
+.. vale off
+
+VariantMigrationTrait
+*********************
+
+.. vale on
+
+To generate schema that matches the entity, use the ``\Mautic\CoreBundle\Doctrine\VariantMigrationTrait`` trait and call ``$this->addVariantSchema()``.
+
+.. vale off
+
+Translated entity Form
+**********************
+
+.. vale on
+
+Add a ``variantParent`` field as shown in the following example. Here, the controller sets the ``variantParent`` value because someone clicked an 'Add A/B Test' button. Your Plugin might need a select list rather than a hidden field, so adapt the code to your needs.
+
+.. code-block:: php
+
+   <?php
+   // plugins/HelloWorldPlugin/Form/Type/WorldType.php
+
+   $transformer = new \Mautic\CoreBundle\Form\Transformer\IdToEntityModelTransformer($this->em, 'HelloWorldBundle:World');
+   $builder->add(
+       $builder->create(
+           'variantParent',
+           'hidden'
+       )->addModelTransformer($transformer)
+   );


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/3c22bf2b-dcc5-4fb4-8180-4d57873ad234)

Ports the legacy developer-docs "Implementing variant (A/B test) support to entities" content into RST at docs/plugin_miscellaneous/variant_entities.rst, replacing the placeholder stub. Documents the VariantInterface, VariantEntityTrait, VariantModelTrait, and VariantMigrationTrait code-level extension points plus the translated entity Form example. Targets base branch 7.2 (repo default), sourced from 7.1 porting issue #419 / parent #418.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_