### PR TITLE
docs: Port "Implementing translation support to entities" page to 7.2

### DIFF
--- a/docs/plugin_miscellaneous/translated_entities.rst
+++ b/docs/plugin_miscellaneous/translated_entities.rst
@@ -12,3 +12,59 @@ Implementing translation support to entities
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Mautic provides helper interfaces and traits that add translated-content support to an entity. Use them so your entity can store a language, relate to a translation parent, and resolve the correct translation at runtime.
+
+``Mautic\CoreBundle\Entity\TranslationEntityInterface``
+    Implement this interface to declare that an entity supports translations. It defines the methods Mautic needs to handle an entity's translations correctly.
+
+``Mautic\CoreBundle\Entity\TranslationEntityTrait``
+    This trait provides the properties and methods that define an entity's language and its relationships to its translation parent and children. In the entity's ``loadMetadata()`` method, call ``self::addTranslationMetadata($builder, self::class)`` to map the translation columns and relationships.
+
+``Mautic\CoreBundle\Model\TranslationModelTrait``
+    Use this trait in the entity's model. It provides ``getTranslatedEntity()``, which determines the entity to use as the translation based on the Contact and/or the request's ``Accept-Language`` header, and ``postTranslationEntitySave()``, which you call at the end of the model's ``saveEntity()`` method to persist the translation relationship.
+
+.. vale off
+
+Translated entity Form
+**********************
+
+.. vale on
+
+Add ``language`` and ``translationParent`` fields to the entity's Form type so Users can set an entity's language and link it to a translation parent. Use an ``IdToEntityModelTransformer`` to convert the submitted parent ID back to an entity:
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Form/Type/WorldType.php
+
+    use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
+    use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+
+    $transformer = new IdToEntityModelTransformer($this->entityManager, World::class);
+
+    $builder->add(
+        $builder->create('translationParent', WorldListType::class, [
+            'label'       => 'mautic.core.form.translation_parent',
+            'label_attr'  => ['class' => 'control-label'],
+            'attr'        => [
+                'class'   => 'form-control',
+                'tooltip' => 'mautic.core.form.translation_parent.help',
+            ],
+            'required'    => false,
+            'multiple'    => false,
+            'placeholder' => 'mautic.core.form.translation_parent.empty',
+            'top_level'   => 'translation',
+            'ignore_ids'  => [(int) $options['data']->getId()],
+        ])->addModelTransformer($transformer)
+    );
+
+    $builder->add('language', LocaleType::class, [
+        'label'      => 'mautic.core.language',
+        'label_attr' => ['class' => 'control-label'],
+        'attr'       => [
+            'class'   => 'form-control',
+            'tooltip' => 'mautic.page.form.language.help',
+        ],
+        'required'   => false,
+    ]);


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/79d03c5f-ccf4-4259-bb1c-0ec1c3b9f7e3)

Ports the legacy translated-entity guide into docs/plugin_miscellaneous/translated_entities.rst (converted from Markdown to RST), replacing the placeholder note with code-level content: the TranslationEntityInterface, TranslationEntityTrait, and TranslationModelTrait helpers, plus a translated-entity Form example. References were verified against mautic/mautic 7.x and updated from the stale legacy names (e.g. TranslationInterface -> TranslationEntityInterface; TranslationMigrationTrait/addTranslationSchema omitted as removed in 6.0). Resolves docs issue #415; targets the 7.2 base branch per the team's porting decision.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Add or adjust Promptless's style guide in [Agent Knowledge Base](https://app.gopromptless.ai/configure/settings) ✍️_