### PR TITLE
docs: Port "Session" service page to 7.2

### DIFF
--- a/docs/plugin_services/session.rst
+++ b/docs/plugin_services/session.rst
@@ -12,3 +12,45 @@ Session
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+In Mautic 7, the session is part of the request. Obtain it from the current ``Request`` rather than from a ``session`` service. Inject ``Symfony\Component\HttpFoundation\RequestStack`` and call ``getSession()`` on the current request:
+
+.. code-block:: php
+
+    <?php
+
+    use Symfony\Component\HttpFoundation\RequestStack;
+
+    final class ExampleService
+    {
+        public function __construct(private RequestStack $requestStack)
+        {
+        }
+
+        public function handleSession(): void
+        {
+            $session = $this->requestStack->getSession();
+
+            // Get all session parameters
+            $all = $session->all();
+
+            // Get a specific parameter, using 'mars' as the default
+            $world = $session->get('helloworld.world', 'mars');
+
+            // Check whether a parameter exists
+            if ($session->has('helloworld.world')) {
+                // Do something.
+            }
+
+            // Set a session parameter
+            $session->set('helloworld.world', 'mars');
+
+            // Remove a session parameter
+            $session->remove('helloworld.world');
+
+            // Clear the whole session
+            $session->clear();
+        }
+    }
+
+Within a controller action, you can also type-hint ``Symfony\Component\HttpFoundation\Request`` as an argument and call ``$request->getSession()`` directly.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/be61bfb6-3ffe-4f8f-8bd4-e2534d8dcf0a)

Ports the legacy Session service guide into docs/plugin_services/session.rst, converting the Markdown to RST and updating the example for Mautic 7. Obtains the session from the current Request via RequestStack::getSession() instead of the removed session service. Resolves docs issue #387 (content sourced from parent 7.0 issue #386).

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_