### PR TITLE
docs: Port "User" service page to 7.2

### DIFF
--- a/docs/plugin_services/user.rst
+++ b/docs/plugin_services/user.rst
@@ -12,3 +12,33 @@ User
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Use the ``Mautic\CoreBundle\Helper\UserHelper`` service to retrieve the currently logged-in User. Inject it into your service or subscriber through the constructor:
+
+.. code-block:: php
+
+    <?php
+
+    use Mautic\CoreBundle\Helper\UserHelper;
+
+    final class ExampleService
+    {
+        public function __construct(private UserHelper $userHelper)
+        {
+        }
+
+        public function describeCurrentUser(): void
+        {
+            $user = $this->userHelper->getUser();
+
+            $firstName = $user->getFirstName();
+            $lastName  = $user->getLastName();
+            $email     = $user->getEmail();
+
+            if ($user->getRole()->isAdmin()) {
+                // Do something for administrators.
+            }
+        }
+    }
+
+``getUser()`` returns the ``Mautic\UserBundle\Entity\User`` entity for the currently logged-in User, which you can then query for profile information. Pass ``true`` to receive ``null`` when the current request has no authenticated User.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/bf42907e-83a3-4660-a311-e37d731e568f)

Ports the legacy User helper guide into docs/plugin_services/user.rst, converting the legacy Markdown to RST and modernizing it to constructor injection of UserHelper. Targets the 7.2 base branch per the team's plan to set content in 7.2 first, then cherry-pick to 7.1/7.0/6.0/5.x. Resolves docs issue #391 (parent #390).

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_