### PR TITLE
docs: Port "Router" service page to 7.2

### DIFF
--- a/docs/plugin_services/router.rst
+++ b/docs/plugin_services/router.rst
@@ -12,3 +12,50 @@ Router
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Use the router to generate URLs from route names. In services, inject ``Symfony\Component\Routing\RouterInterface`` and call ``generate()``:
+
+.. code-block:: php
+
+    <?php
+
+    use Symfony\Component\Routing\RouterInterface;
+    use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+    final class ExampleService
+    {
+        public function __construct(private RouterInterface $router)
+        {
+        }
+
+        public function buildUrls(): void
+        {
+            // Relative URL
+            $url = $this->router->generate('plugin_helloworld_admin');
+
+            // URL with placeholders
+            $url = $this->router->generate('plugin_helloworld_world', ['world' => 'mars']);
+
+            // Absolute URL
+            $absoluteUrl = $this->router->generate(
+                'plugin_helloworld_admin',
+                [],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
+        }
+    }
+
+Generating URLs in templates
+****************************
+
+Mautic 7 uses Twig templates. Use the ``path()`` and ``url()`` Twig functions instead of the router service:
+
+.. code-block:: twig
+
+    {# Relative path #}
+    <a href="{{ path('plugin_helloworld_admin') }}">Admin</a>
+
+    {# Absolute URL #}
+    <a href="{{ url('plugin_helloworld_admin') }}">Admin</a>
+
+The legacy PHP-template helper ``$view['router']`` no longer exists in Mautic 7.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/6beea01d-f515-4f07-8044-7a5765f4d0f2)

Ports the legacy Router guide into plugin_services/router.rst on the 7.2 base branch, converting the Markdown source to RST. Injects Symfony's RouterInterface and calls generate() in services, and documents the Twig path()/url() functions for templates (the legacy $view['router'] PHP-template helper no longer exists in Mautic 7). Resolves docs issue #383.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_