### PR TITLE
docs: Port "Request" service page to 7.2

### DIFF
--- a/docs/plugin_services/request.rst
+++ b/docs/plugin_services/request.rst
@@ -12,3 +12,54 @@ Request
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Inject ``Symfony\Component\HttpFoundation\RequestStack`` and call ``getCurrentRequest()`` to access the current request:
+
+.. code-block:: php
+
+    <?php
+
+    use Symfony\Component\HttpFoundation\RequestStack;
+
+    final class ExampleService
+    {
+        public function __construct(private RequestStack $requestStack)
+        {
+        }
+
+        public function readRequest(): void
+        {
+            $request = $this->requestStack->getCurrentRequest();
+
+            // $_GET
+            $get = $request->query->all();
+
+            // $_POST
+            $post = $request->request->all();
+
+            // $_COOKIE
+            $cookies = $request->cookies->all();
+
+            // $_SERVER
+            $server = $request->server->all();
+
+            // Headers
+            $headers = $request->headers->all();
+
+            // Attributes - custom parameters
+            $attributes = $request->attributes->all();
+
+            // Check whether a parameter exists
+            if ($request->request->has('hello')) {
+                // Do something.
+            }
+
+            // Retrieve the value of a specific parameter, using 'mars' as the default
+            $world = $request->query->get('world', 'mars');
+
+            // Set a custom request value
+            $request->attributes->set('hello', 'world');
+        }
+    }
+
+Within a controller action, you can also type-hint ``Symfony\Component\HttpFoundation\Request`` as an argument and Symfony injects the current request automatically.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/475cece7-6d89-4ed7-9de0-5eb868c0e19e)

Ports the legacy Request guide into docs/plugin_services/request.rst, converting the Markdown to RST and updating it to inject Symfony's RequestStack and call getCurrentRequest() per Mautic 7.x. Content sourced from 7.1 porting issue #379 (parent #378), targeting the 7.2 base branch. The page is already wired into the plugin_services toctree.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Point @Promptless at some of your docs debt and have it clean them up in the background 🧹_