### PR TITLE
docs: Port "Plugin config helper" service page to 7.2

### DIFF
--- a/docs/plugin_services/plugin_config_helper.rst
+++ b/docs/plugin_services/plugin_config_helper.rst
@@ -12,3 +12,25 @@ Plugin config helper
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Use ``Mautic\CoreBundle\Helper\BundleHelper`` to read the configuration array declared in a Plugin's ``Config/config.php`` file. Inject the helper into your service:
+
+.. code-block:: php
+
+    <?php
+
+    use Mautic\CoreBundle\Helper\BundleHelper;
+
+    final class ExampleService
+    {
+        public function __construct(private BundleHelper $bundleHelper)
+        {
+        }
+
+        public function readMenu(): array
+        {
+            return $this->bundleHelper->getBundleConfig('HelloWorldBundle', 'menu', true);
+        }
+    }
+
+``getBundleConfig(string $bundleName, string $configKey = '', bool $includePlugins = false)`` returns the requested section of a bundle or Plugin's configuration. Omit ``$configKey`` to return the whole configuration array. The method throws an exception when the bundle or the requested key doesn't exist. ``BundleHelper`` also provides ``getMauticBundles()`` and ``getPluginBundles()`` to list the registered bundles and Plugins.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/87dab779-94eb-4c76-aa49-237c109f32ed)

Ports the legacy Plugin config helper guide into docs/plugin_services/plugin_config_helper.rst, converting the Markdown source to RST. Documents injecting BundleHelper and using getBundleConfig() to read a Plugin's Config/config.php array. Content sourced from 7.1 porting issue #375 (parent #374); targets base branch 7.2.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Attach PDFs in Slack messages to Promptless—it can even extract images from them 📎_