### PR TITLE
docs: Port "Config parameters" service page to 7.2

### DIFF
--- a/docs/plugin_services/parameters.rst
+++ b/docs/plugin_services/parameters.rst
@@ -12,3 +12,25 @@ Config parameters
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Use ``Mautic\CoreBundle\Helper\CoreParametersHelper`` to read Mautic's configuration parameters, including any your Plugin declares. Inject the helper into your service:
+
+.. code-block:: php
+
+    <?php
+
+    use Mautic\CoreBundle\Helper\CoreParametersHelper;
+
+    final class ExampleService
+    {
+        public function __construct(private CoreParametersHelper $coreParametersHelper)
+        {
+        }
+
+        public function isApiEnabled(): bool
+        {
+            return (bool) $this->coreParametersHelper->get('helloworld_api_enabled', false);
+        }
+    }
+
+Call ``get(string $name, $default = null)`` to read a single parameter with a fallback value. ``CoreParametersHelper`` also provides ``has()`` to confirm whether a parameter is set and ``all()`` to return every parameter.

--- a/docs/plugin_services/parameters.rst
+++ b/docs/plugin_services/parameters.rst
@@ -1,18 +1,6 @@
 Config parameters
 #################
 
-.. vale off
-
-.. note::
-
-   The content for this page requires a major update. The legacy page contains outdated and potentially inaccurate information. You can still access it in the :xref:`legacy repository`.
-
-   If you're interested in helping develop the new content for this page and others, consider joining the documentation efforts.
-
-   Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
-
-.. vale on
-
 Use ``Mautic\CoreBundle\Helper\CoreParametersHelper`` to read Mautic's configuration parameters, including any your Plugin declares. Inject the helper into your service:
 
 .. code-block:: php

--- a/docs/plugin_services/parameters.rst
+++ b/docs/plugin_services/parameters.rst
@@ -33,4 +33,4 @@ Use ``Mautic\CoreBundle\Helper\CoreParametersHelper`` to read Mautic's configura
         }
     }
 
-Call ``get(string $name, $default = null)`` to read a single parameter with a fallback value. ``CoreParametersHelper`` also provides ``has()`` to confirm whether a parameter is set and ``all()`` to return every parameter.
+Call ``get(string $name, $default = null)`` to read a single parameter with a fallback value. ``CoreParametersHelper`` also provides ``has()`` to confirm whether a parameter exists and ``all()`` to return every parameter.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/62028da6-3e27-401c-967d-71fd07548452)

Ports the legacy Config parameters guide into plugin_services/parameters.rst on the 7.2 base branch, converting the legacy Markdown to RST and modernizing it to inject CoreParametersHelper and use get()/has()/all(). Mirrors the reviewed 7.1 port. Resolves docs issue #367.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Enable auto-create PR in your [Configuration](https://app.gopromptless.ai/configuration) to review suggestions directly in GitHub 🤖_