### PR TITLE
docs: Port "Paths helper" plugin service page from legacy dev docs

### DIFF
--- a/docs/plugin_services/paths_helper.rst
+++ b/docs/plugin_services/paths_helper.rst
@@ -3,12 +3,56 @@ Paths helper
 
 .. vale off
 
-.. note::
-
-   The content for this page requires a major update. The legacy page contains outdated and potentially inaccurate information. You can still access it in the :xref:`legacy repository`.
-
-   If you're interested in helping develop the new content for this page and others, consider joining the documentation efforts.
-
-   Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
+The Paths helper resolves filesystem paths for Mautic's system locations - images, themes, cache, logs, and temporary files - so your Plugin can read from and write to the right directory without hardcoding the directory structure.
 
 .. vale on
+
+Using the helper
+****************
+
+Inject ``Mautic\CoreBundle\Helper\PathsHelper`` into your service, or retrieve the ``mautic.helper.paths`` service from the container in legacy code.
+
+.. code-block:: php
+
+   <?php
+
+   use Mautic\CoreBundle\Helper\PathsHelper;
+
+   final class ExampleService
+   {
+       public function __construct(private PathsHelper $pathsHelper)
+       {
+       }
+
+       public function locateImages(): void
+       {
+           // Relative path, for example "media/images"
+           $relativeImagesDir = $this->pathsHelper->getSystemPath('images');
+
+           // Absolute path, for example "/home/user/public_html/media/images"
+           $absoluteImagesDir = $this->pathsHelper->getSystemPath('images', true);
+       }
+   }
+
+* Service name: ``mautic.helper.paths``
+* Class: ``Mautic\CoreBundle\Helper\PathsHelper``
+
+Retrieving system paths
+***********************
+
+Call ``getSystemPath(string $name, bool $fullPath = false)`` to resolve a system location. By default, it returns a path relative to the Mautic root. Pass ``true`` as the second argument to get the absolute path instead. The ``cache``, ``logs``, and ``temporary`` locations are always absolute, regardless of the ``$fullPath`` argument.
+
+Commonly used names include:
+
+* ``images``: the media images directory.
+* ``themes``: the Themes directory.
+* ``assets``: the uploaded Assets directory.
+* ``cache``: the kernel cache directory - always absolute.
+* ``logs``: the kernel logs directory - always absolute.
+* ``temporary`` or ``tmp``: a directory for temporary files - always absolute.
+
+Passing a name that Mautic doesn't recognize throws an ``\InvalidArgumentException``.
+
+.. tip::
+
+   Use the ``temporary`` or ``tmp`` name when your Plugin needs to store temporary files. Reserve the ``cache`` location for cached data so your temporary files don't collide with Mautic's cache.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/dd103fc3-eb49-4b93-b765-dde143d339d4)

Replaces the stub "Paths helper" page (docs/plugin_services/paths_helper.rst) with ported and updated content from the legacy developer docs. Documents the mautic.helper.paths service, DI usage of PathsHelper, and getSystemPath() including relative vs. absolute paths and the tmp/temporary location. Grounded in the current PathsHelper class on mautic/mautic 7.x. Targets the 7.2 base branch per issues #371/#370.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Use Slack message actions (⋯ menu → Update Docs) to capture doc updates without interrupting conversations 💬_