### PR TITLE
docs: Port "Commands" page from legacy dev docs into RST (7.2)

### DIFF
--- a/docs/links/symfony_console_component.py
+++ b/docs/links/symfony_console_component.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Symfony Console Component"
+link_text = "Symfony's Console Component"
+link_url = "https://symfony.com/doc/current/console.html"
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/plugin_miscellaneous/commands.rst
+++ b/docs/plugin_miscellaneous/commands.rst
@@ -1,14 +1,78 @@
 Commands
 ########
 
-.. vale off
+You can add new console commands to your Plugin using :xref:`Symfony Console Component`. A command lives in your Plugin's ``Command`` directory and extends ``Symfony\Component\Console\Command\Command``.
 
-.. note::
+.. code-block:: php
 
-   The content for this page requires a major update. The legacy page contains outdated and potentially inaccurate information. You can still access it in the :xref:`legacy repository`.
+    <?php
+    // plugins/HelloWorldBundle/Command/WorldCommand.php
 
-   If you're interested in helping develop the new content for this page and others, consider joining the documentation efforts.
+    namespace MauticPlugin\HelloWorldBundle\Command;
 
-   Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Output\OutputInterface;
 
-.. vale on
+    #[AsCommand(
+        name: 'mautic:helloworld:greet',
+        description: 'Greets the world.'
+    )]
+    class WorldCommand extends Command
+    {
+        protected function execute(InputInterface $input, OutputInterface $output): int
+        {
+            $output->writeln('Hello, world!');
+
+            return Command::SUCCESS;
+        }
+    }
+
+Registering commands
+====================
+
+Since Mautic 5, Autowiring and autoconfiguration handle commands for you, so you don't need to register them in your Plugin's ``config.php`` file. Mautic automatically tags any service that extends the Symfony ``Command`` class with ``console.command``. If you turn off autoconfiguration for your Plugin, register the command manually under the ``commands`` key in ``config.php``, which Mautic tags with :xref:`Symfony as a console command<Symfony console command tag>`.
+
+Moderated commands
+==================
+
+Some commands shouldn't run more than one instance at a time, such as those that process queues or send scheduled Broadcasts. Extend ``Mautic\CoreBundle\Command\ModeratedCommand`` to lock the command so that only a single instance runs concurrently. Call ``checkRunStatus()`` at the start of ``execute()`` to acquire the lock, then call ``completeRun()`` once the work finishes to release it.
+
+.. code-block:: php
+
+    <?php
+    // plugins/HelloWorldBundle/Command/WorldCommand.php
+
+    namespace MauticPlugin\HelloWorldBundle\Command;
+
+    use Mautic\CoreBundle\Command\ModeratedCommand;
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Output\OutputInterface;
+
+    #[AsCommand(
+        name: 'mautic:helloworld:greet',
+        description: 'Greets the world.'
+    )]
+    class WorldCommand extends ModeratedCommand
+    {
+        protected function execute(InputInterface $input, OutputInterface $output): int
+        {
+            // Stop here if another instance of this command is already running.
+            if (!$this->checkRunStatus($input, $output)) {
+                return Command::SUCCESS;
+            }
+
+            // Do the work.
+            $output->writeln('Hello, world!');
+
+            // Release the lock.
+            $this->completeRun();
+
+            return Command::SUCCESS;
+        }
+    }
+
+``ModeratedCommand`` adds the ``--bypass-locking``, ``--timeout``, and ``--lock_mode`` options and locks on the command name by default. When a single command needs to run in parallel for different targets, such as one lock per entity ID, pass a ``$moderationKey`` as the third argument to ``checkRunStatus()``.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/1d8fa305-7542-428d-9be0-924235683639)

Ports the plugin_miscellaneous/commands page from the legacy Markdown docs into RST on the 7.2 branch, replacing the placeholder. Content is updated for Mautic 7.x: registering console commands via autowiring/autoconfiguration, the modern #[AsCommand] attribute, and the current ModeratedCommand locking API (checkRunStatus/completeRun). Source: 7.1 porting issue #395 and parent 7.0 issue #394.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Enable auto-create PR in your [Configuration](https://app.gopromptless.ai/configuration) to review suggestions directly in GitHub 🤖_