### PR TITLE
docs: Port "Model factory" service page to 7.2

### DIFF
--- a/docs/plugin_services/model_factory.rst
+++ b/docs/plugin_services/model_factory.rst
@@ -12,3 +12,35 @@ Model factory
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Use ``Mautic\CoreBundle\Factory\ModelFactory`` when you don't know which model a service needs until runtime - for example, when the Channel and Channel ID live in the database and your code has to look up the Channel entity. Inject the factory into your service:
+
+.. code-block:: php
+
+    <?php
+
+    use Mautic\CoreBundle\Factory\ModelFactory;
+
+    final class ExampleService
+    {
+        public function __construct(private ModelFactory $modelFactory)
+        {
+        }
+
+        public function describeChannelEntity(string $channel, int $channelId): void
+        {
+            if ($this->modelFactory->hasModel($channel)) {
+                $model = $this->modelFactory->getModel($channel);
+
+                if ($entity = $model->getEntity($channelId)) {
+                    echo $entity->getName();
+                }
+            }
+        }
+    }
+
+The factory exposes two methods: ``hasModel(string $modelNameKey)`` checks whether a model exists, and ``getModel(string $modelNameKey)`` returns it. Both take the same key format as the controller ``getModel()`` helper - so ``email`` resolves to ``Mautic\EmailBundle\Model\EmailModel``.
+
+.. tip::
+
+   When you know the model at build time, inject the model class directly instead of resolving it through the factory.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/922228c4-0dd0-4fae-8c04-2313e35ed44a)

Ports the legacy Model factory guide into docs/plugin_services/model_factory.rst, converting the Markdown source to RST and modernizing the example to constructor injection of ModelFactory. Documents the hasModel()/getModel() runtime model-resolution API. Resolves docs issue #363; targets the 7.2 base branch per the porting batch.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Use labels in the [Promptless dashboard](https://app.gopromptless.ai) to categorize suggestions by release or team 🏷️_