### PR TITLE
docs: Port "Factory" service page to 7.2

### DIFF
--- a/docs/plugin_services/factory.rst
+++ b/docs/plugin_services/factory.rst
@@ -12,3 +12,29 @@ Factory
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+.. warning::
+
+   ``Mautic\Factory\MauticFactory`` is removed in Mautic 7. It was deprecated in Mautic 2.0 and removed in Mautic 3.0. Use dependency injection instead.
+
+Earlier Mautic versions exposed a single ``MauticFactory`` service - available as ``$this->factory`` in controllers and models - that aggregated many dependencies. Mautic 7 relies on autowired dependency injection, so you inject the specific services you need directly through the constructor:
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\ORM\EntityManagerInterface;
+    use Mautic\CoreBundle\Helper\CoreParametersHelper;
+    use Mautic\CoreBundle\Helper\UserHelper;
+
+    final class ExampleService
+    {
+        public function __construct(
+            private EntityManagerInterface $entityManager,
+            private CoreParametersHelper $coreParametersHelper,
+            private UserHelper $userHelper,
+        ) {
+        }
+    }
+
+To resolve a model whose type isn't known until runtime, inject :doc:`Model factory</plugin_services/model_factory>` instead of the removed factory.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/393ccaa3-913d-412d-b463-6bd24940381e)

Ports the legacy "Factory Service" developer-docs page into RST at docs/plugin_services/factory.rst on the 7.2 base branch. Documents that MauticFactory was deprecated in 2.0 and removed in 3.0 (gone in Mautic 7), and directs developers to autowired dependency injection with a constructor example, cross-linking the Model factory page for runtime model resolution.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Leave inline comments with `@Promptless` on suggestion diffs in the [Promptless dashboard](https://app.gopromptless.ai/suggestions) for targeted refinements 💬_