### PR TITLE
docs: Port "Database or entity manager" service page to 7.2

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -113,6 +113,7 @@ noindex
 OAuth
 OAuth1a
 OAuth2
+ORM
 Packagist
 patch
 PATCH

--- a/docs/plugin_services/database.rst
+++ b/docs/plugin_services/database.rst
@@ -12,3 +12,32 @@ Database or entity manager
    Please read the :xref:`dev docs contributing guidelines` and :xref:`Contributing to Mautic’s documentation` to get started.
 
 .. vale on
+
+Doctrine provides both an ORM and a DBAL layer. To work with a bundle's repositories and entities, use the entity manager by injecting ``Doctrine\ORM\EntityManagerInterface`` into your service:
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\ORM\EntityManagerInterface;
+
+    final class ExampleService
+    {
+        public function __construct(private EntityManagerInterface $entityManager)
+        {
+        }
+
+        public function incrementVisits(): void
+        {
+            $repository = $this->entityManager->getRepository(World::class);
+            $worlds     = $repository->getEntities();
+
+            foreach ($worlds as $world) {
+                $world->upVisitCount();
+            }
+
+            $repository->saveEntities($worlds);
+        }
+    }
+
+For direct database access, inject the DBAL connection, ``Doctrine\DBAL\Connection``, instead. In a controller, you can also reach the entity manager through the injected ``Doctrine\Persistence\ManagerRegistry``.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/65e6c570-3930-4831-bf17-146b908d0f52)

Ports the legacy Database/entity manager guide from the archived developer-documentation repo into docs/plugin_services/database.rst, converting Markdown to RST and modernizing the example to inject EntityManagerInterface (with DBAL and ManagerRegistry alternatives). Adds ORM to the Mautic Vale vocabulary. Targets the 7.2 base branch per issue #347.

**Trigger Events**
- [Message in Slack channel #docs-notifications: The reason of `blocked` label is to set content, structure, and tone in one branch, then backport/cherry pick i...](https://mautic.slack.com/archives/C0114H9GRH8/p1783619085361999)

---

_Tip: Use Slack message actions (⋯ menu → Update Docs) to capture doc updates without interrupting conversations 💬_