### PR TITLE
docs: Document tableheader.html.twig helper and its new tooltip parameter

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -160,7 +160,7 @@ themes
 Themes
 timeframe
 Todo
-tooltips?
+tooltip
 Transifex
 Translator
 TRUE

--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -160,7 +160,7 @@ themes
 Themes
 timeframe
 Todo
-tooltip
+tooltips?
 Transifex
 Translator
 TRUE

--- a/docs/design_templates/table_header.rst
+++ b/docs/design_templates/table_header.rst
@@ -24,7 +24,7 @@ Mautic passes ``tooltip`` through the ``trans`` filter, so you can supply either
 
 Columns that don't pass ``tooltip`` render as before, with no tooltip markup, so existing list views stay unaffected until you opt in.
 
-You don't need any JavaScript setup. Mautic initializes tooltips globally for any element carrying ``data-toggle="tooltip"``, so emitting the attribute is enough for the tooltip to appear. Mautic escapes the value you pass with the ``html_attr`` filter before rendering it into the ``data-original-title`` attribute.
+You don't need any JavaScript setup. Mautic initializes tooltip support globally for any element carrying ``data-toggle="tooltip"``, so emitting the attribute is enough for the tooltip to appear. Mautic escapes the value you pass with the ``html_attr`` filter before rendering it into the ``data-original-title`` attribute.
 
 Common parameters
 *****************
@@ -34,7 +34,7 @@ Configure the header by passing keys when you include the template. The most com
 * ``text``: the column label. Passed through the ``trans`` filter, so it accepts a translation key or a literal string.
 * ``tooltip``: optional tooltip text shown on hover. Passed through the ``trans`` filter.
 * ``sessionVar``: the session namespace for the list. When set, the header renders as a sortable or filterable column, and Mautic persists the sort and filter state under this key.
-* ``orderBy``: the field to sort by. When set, the label becomes a clickable sort link; when omitted, it renders as a static label.
+* ``orderBy``: the field to sort by. When set, the label becomes a clickable sort link, and when omitted, it renders as a static label.
 * ``class``: extra CSS class or classes to add to the ``<th>`` element.
 * ``filterBy``: the field to filter by. When set, the header renders a per-column filter input.
 * ``target``: the CSS selector for the table container that receives the sort and filter updates. Defaults to ``.page-list``.

--- a/docs/design_templates/table_header.rst
+++ b/docs/design_templates/table_header.rst
@@ -1,9 +1,6 @@
 Table header template
 #####################
 
-Introduction
-************
-
 The ``tableheader.html.twig`` template renders the ``<th>`` header cells for Mautic's list views. It handles the bulk-select checkbox column, plain non-sortable columns, and sortable or filterable columns, wiring up the sort links, per-column filter inputs, and session-persisted sort state for you. Include it once per column when you build a list table, rather than writing the header markup by hand.
 
 Adding a header tooltip

--- a/docs/design_templates/table_header.rst
+++ b/docs/design_templates/table_header.rst
@@ -1,0 +1,40 @@
+Table header template
+#####################
+
+Introduction
+************
+
+The ``tableheader.html.twig`` template renders the ``<th>`` header cells for Mautic's list views. It handles the bulk-select checkbox column, plain non-sortable columns, and sortable or filterable columns, wiring up the sort links, per-column filter inputs, and session-persisted sort state for you. Include it once per column when you build a list table, rather than writing the header markup by hand.
+
+Adding a header tooltip
+***********************
+
+Pass an optional ``tooltip`` key to show a tooltip when a User hovers over a column header. The tooltip works on plain non-sortable columns and on sortable or filterable columns, as well as the bulk-select checkbox column, which already supported it.
+
+.. code-block:: twig
+
+   {{ include('@MauticCore/Helper/tableheader.html.twig', {
+       text: 'mautic.lead.list.header',
+       tooltip: 'mautic.lead.list.header.tooltip',
+       sessionVar: 'contact',
+       orderBy: 'l.name',
+   }) }}
+
+Mautic passes ``tooltip`` through the ``trans`` filter, so you can supply either a translation key or a literal string. Reload the list view and hover over the column header to see the tooltip.
+
+Columns that don't pass ``tooltip`` render as before, with no tooltip markup, so existing list views stay unaffected until you opt in.
+
+You don't need any JavaScript setup. Mautic initializes tooltips globally for any element carrying ``data-toggle="tooltip"``, so emitting the attribute is enough for the tooltip to appear. Mautic escapes the value you pass with the ``html_attr`` filter before rendering it into the ``data-original-title`` attribute.
+
+Common parameters
+*****************
+
+Configure the header by passing keys when you include the template. The most commonly used keys are:
+
+* ``text``: the column label. Passed through the ``trans`` filter, so it accepts a translation key or a literal string.
+* ``tooltip``: optional tooltip text shown on hover. Passed through the ``trans`` filter.
+* ``sessionVar``: the session namespace for the list. When set, the header renders as a sortable or filterable column, and Mautic persists the sort and filter state under this key.
+* ``orderBy``: the field to sort by. When set, the label becomes a clickable sort link; when omitted, it renders as a static label.
+* ``class``: extra CSS class or classes to add to the ``<th>`` element.
+* ``filterBy``: the field to filter by. When set, the header renders a per-column filter input.
+* ``target``: the CSS selector for the table container that receives the sort and filter updates. Defaults to ``.page-list``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,7 @@ There are several ways to support Mautic other than contributing with code.
 
    design_templates/accordion
    design_templates/protip
+   design_templates/table_header
    design_templates/tiles
 
 .. toctree::


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/2d1d1758-178d-4770-a9a0-a676b0a0fc07)

Adds a "Table header template" page under Design templates documenting the `@MauticCore/Helper/tableheader.html.twig` helper, focused on the new optional `tooltip` parameter added in mautic/mautic PR #16517. Covers how to add a header tooltip to any list column, the no-JS-setup behavior, `html_attr` escaping, and the helper's common parameters. Also registers the page in the toctree and adds `tooltip` to the Mautic vocabulary.

**Trigger Events**
- [mautic/mautic PR #16517: Support header tooltip on sortable and non-sortable table columns](https://github.com/mautic/mautic/pull/16517)

---

**Review feedback addressed (@adiati98)**
- _"Remove this, keep the 'tooltip'."_ — Applied verbatim: reverted the Mautic vocabulary entry from `tooltips?` back to `tooltip`.
- `orderBy` bullet suggestion — Applied verbatim: `; when omitted` → `, and when omitted`.
- Follow-on fix: reverting the vocabulary to singular-only made Vale flag the plural "tooltips" in the prose, so "Mautic initializes tooltips globally" was reworded to "Mautic initializes tooltip support globally" to satisfy the linter while keeping the vocabulary as the reviewer requested. Vale now passes with no errors.
- _"I think we can jump straight to the paragraph. Remove this."_ (on the "Introduction" heading) — Applied verbatim: removed the "Introduction" subsection heading and its underline so the page opens directly with the intro paragraph. Vale passes with no errors.

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_
