### PR TITLE
docs: Document inLast and inNext Segment filter operators in the REST API reference

### DIFF
--- a/docs/rest_api/segments.rst
+++ b/docs/rest_api/segments.rst
@@ -813,6 +813,12 @@ Date fields
      - Occurrence before the specified date
    * - ``lte``
      - Occurrence on or before the specified date
+   * - ``inLast``
+     - Occurrence within the interval leading up to today
+   * - ``inNext``
+     - Occurrence between today and the end of the interval
+
+For ``inLast`` and ``inNext``, send ``properties.filter`` as an object with an ``interval`` integer and a ``unit`` of ``day``, ``month``, or ``year`` instead of a scalar value. Refer to :ref:`In the last and In the next filter <in the last and in the next filter>` for an example.
 
 Select or multi-select fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -896,5 +902,28 @@ Behavior action filter
        "operator": "startsWith",
        "properties": {
            "filter": "acme"
+       }
+   }
+
+.. _in the last and in the next filter:
+
+In the last and In the next filter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``inLast`` and ``inNext`` operators take an interval and a unit instead of a scalar date. Send ``properties.filter`` as an object with an ``interval`` integer and a ``unit`` of ``day``, ``month``, or ``year``:
+
+.. code-block:: json
+
+   {
+       "glue": "and",
+       "field": "date_modified",
+       "object": "lead",
+       "type": "datetime",
+       "operator": "inLast",
+       "properties": {
+           "filter": {
+               "interval": 1,
+               "unit": "day"
+           }
        }
    }


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/999e5fee-3945-43df-90b3-4e9b0e85350b)

Adds the two new date/datetime operators from mautic/mautic PR #16574 — inLast and inNext — to the Segments REST API reference. Documents them in the Date fields operator table and adds a filter example showing the interval/unit object payload shape (which differs from the scalar filter value used by other date operators).

**Trigger Events**
- [mautic/mautic PR #16574: In the last next segment filters](https://github.com/mautic/mautic/pull/16574)

---

_Tip: Use Slack message actions (⋯ menu → Update Docs) to capture doc updates without interrupting conversations 💬_