### PR TITLE
Fix broken Symfony event-subscribers link that fails the docs link check

### DIFF
--- a/docs/links/symfony_docs_event_subscribers.py
+++ b/docs/links/symfony_docs_event_subscribers.py
@@ -2,7 +2,7 @@ from . import link
 
 link_name = "Symfony event subscribers"
 link_text = "event subscribers"
-link_url = "https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers"
+link_url = "https://symfony.com/doc/current/components/event_dispatcher.html#event_dispatcher-using-event-subscribers"
 
 link.xref_links.update({link_name: (link_text, link_url)})
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/c5aedf40-a2eb-4d64-a013-dcff842775f1)

The `Check links` CI step scans the whole docs site and was failing every PR because the `Symfony event subscribers` cross-reference (used on the `plugins/event_listeners.rst` "Event subscribers" section) pointed at `https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers`. Symfony renamed that anchor, so the link no longer resolves.

This updates the link registry (`docs/links/symfony_docs_event_subscribers.py`) to the current anchor `#event_dispatcher-using-event-subscribers`, which is Symfony's Sphinx reference label for the "Creating an Event Subscriber" section. This is the only broken link the build reported, so the fix clears the site-wide link check. No prose or RST content changes.

**Trigger Events**
- [GitHub CI failure on developer-documentation-new PR #619 (Check links)](https://github.com/mautic/developer-documentation-new/actions/runs/31597351043/job/94116003193)
