### PR TITLE
Fix broken Symfony event subscribers link that fails the docs linkcheck build

### DIFF
--- a/docs/links/symfony_docs_event_subscribers.py
+++ b/docs/links/symfony_docs_event_subscribers.py
@@ -2,7 +2,7 @@ from . import link
 
 link_name = "Symfony event subscribers"
 link_text = "event subscribers"
-link_url = "https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers"
+link_url = "https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber"
 
 link.xref_links.update({link_name: (link_text, link_url)})
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/cdc76fed-cadf-462f-ae27-c8a00a236b4f)

The docs `build` job's link-check step (`sphinx-build -b linkcheck`) fails on every PR because the shared 'Symfony event subscribers' cross-reference points to a Symfony docs anchor that no longer exists: `https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers`. Symfony moved the page to `event_dispatcher.html` and renamed the section, so the old anchor now returns 'Anchor not found' and breaks the build.

This updates the xref definition in `docs/links/symfony_docs_event_subscribers.py` to the current canonical URL and anchor, `https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber` (verified reachable with the anchor present). The rendered link (used from `docs/plugins/event_listeners.rst`) still reads 'event subscribers' and now points to the live Symfony section.

File touched: `docs/links/symfony_docs_event_subscribers.py`.

**Trigger Events**
- [Failing docs linkcheck build (GitHub Actions run)](https://github.com/mautic/developer-documentation-new/actions/runs/31803385928/job/94776397229)