### PR TITLE
Ignore the Open Collective URL in the docs linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,9 @@ html_css_files = ['tablefix.css']
 # A little context on the reason for ignoring is greatly appreciated!
 linkcheck_ignore = [
    # github anchors cause failures, so do not check any github url with an anchor
-   r'^https://github.com/.*#.*'
+   r'^https://github.com/.*#.*',
+   # Open Collective returns 403 to the linkcheck bot even though the page is live
+   r'^https://opencollective\.com/mautic$'
 ]
 
 # Ensure that autosectionlabel will produce unique names


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/fd1f2ae0-cc6d-4ae1-abe5-cc3878494d90)

The `make checklinks` CI step (the "Check links" job) fails whenever it hits `https://opencollective.com/mautic`, which returns `HTTP 403 (Forbidden)` to the linkcheck bot even though the page is live and valid — it's Mautic's real Open Collective profile, linked from `docs/index.rst` via `docs/links/mautic_open_collective.py`. Because Sphinx linkcheck builds the whole documentation set, this one broken result fails the check on every open docs pull request against `7.2`, not just the PR that happened to surface it.

This adds `https://opencollective.com/mautic` to `linkcheck_ignore` in `docs/conf.py`, alongside the existing GitHub-anchor exemption and with a comment noting the reason. Configuration-only change; no documentation prose is affected.

**Trigger Events**
- [GitHub Actions "Check links" failure on developer-documentation-new PR #627](https://github.com/mautic/developer-documentation-new/actions/runs/32461079296/job/96707978321)
