### PR TITLE
Update custom SMS transport docs for the AutowireIterator refactor (Mautic 8)

### DIFF
--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -16,7 +16,7 @@ Transport interfaces
 
 A custom transport implements one or more interfaces from the ``Mautic\SmsBundle\Sms`` namespace, depending on the capabilities it provides. These interfaces live in Mautic core, so your Plugin implements them rather than redefining them.
 
-* :xref:`TransportInterface source` - the base interface every transport must implement. It defines ``sendSms(Lead $lead, $content)``, which sends a single message and returns ``true`` on success or an error message string on failure.
+* :xref:`TransportInterface source` - the base interface every transport must implement. It defines ``sendSms(Lead $lead, $content)``, which sends a single message and returns ``true`` on success or an error message string on failure. It also declares ``getIntegrationAlias(): string``, which returns the transport's integration alias - the name shown in the UI for this transport.
 * :xref:`BulkTransportInterface source` - extends ``TransportInterface`` to enable native batch sending through ``sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection``. Transports that implement only ``TransportInterface`` fall back to iterative per-Contact sending.
 * :xref:`MMSTransportInterface source` - adds MMS support with media attachments through ``sendMms(Lead $lead, string $content, array $media): bool|string``. Because of carrier restrictions, MMS currently works only for recipients in the US, Canada, and Australia.
 
@@ -64,6 +64,11 @@ Implement the interfaces for the capabilities your provider supports. The exampl
 
    class HelloWorldTransport implements TransportInterface, BulkTransportInterface, MMSTransportInterface
    {
+       public function getIntegrationAlias(): string
+       {
+           return 'Hello World SMS';
+       }
+
        public function sendSms(Lead $lead, $content)
        {
            $phone = $lead->getPhone();
@@ -104,7 +109,7 @@ Implement the interfaces for the capabilities your provider supports. The exampl
 Registering the transport
 ==========================
 
-Register the transport in your Plugin's ``Config/config.php`` by tagging the service with ``mautic.sms_transport``. Mautic builds Plugin ``config.php`` services through its own ``ServicePass`` compiler pass rather than Symfony autoconfiguration, so implementing ``TransportInterface`` doesn't tag the service for you, and you must declare the tag explicitly. The ``SmsTransportPass`` compiler pass then collects every service carrying this tag, and the ``integrationAlias`` tag argument sets the name shown in the UI.
+Register the transport in your Plugin's ``Config/config.php`` by tagging the service with ``mautic.sms_transport``. Mautic builds Plugin ``config.php`` services through its own ``ServicePass`` compiler pass rather than Symfony autoconfiguration, so implementing ``TransportInterface`` doesn't tag the service for you, and you must declare the tag explicitly. Mautic's ``TransportChain`` collects every service carrying the tag, and the name shown in the UI comes from the transport's ``getIntegrationAlias()`` method.
 
 .. code-block:: php
 
@@ -115,11 +120,8 @@ Register the transport in your Plugin's ``Config/config.php`` by tagging the ser
        'services' => [
            'other' => [
                'mautic.sms.transport.helloworld' => [
-                   'class'        => \MauticPlugin\HelloWorldBundle\Sms\Transport\HelloWorldTransport::class,
-                   'tag'          => 'mautic.sms_transport',
-                   'tagArguments' => [
-                       'integrationAlias' => 'Hello World SMS',
-                   ],
+                   'class' => \MauticPlugin\HelloWorldBundle\Sms\Transport\HelloWorldTransport::class,
+                   'tag'   => 'mautic.sms_transport',
                ],
            ],
        ],

--- a/docs/plugins/config.rst
+++ b/docs/plugins/config.rst
@@ -632,8 +632,8 @@ Mautic uses the follow tags to register services as described below.
       - Supported tag arguments
       - Description
     * - ``mautic.sms_transport``
-      - ``['integrationAlias' => 'Name to display in the UI for this transport.']``
-      - Register this service as a Text Message transport.
+      - none
+      - Register this service as a Text Message transport. The transport's displayed name comes from its ``getIntegrationAlias()`` method rather than a tag argument.
     * - ``mautic.sms_callback_handler``
       - none
       - Registers this service to handle Webhooks from a Text Message transport.


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/f5dd42d3-0a77-4710-98d3-9062ee7a7bce)

Mautic 8 replaces the `SmsTransportPass` compiler pass with a Symfony `#[AutowireIterator('mautic.sms_transport')]` argument on `TransportChain`, and adds a required `getIntegrationAlias(): string` method to `TransportInterface`. Because a tagged iterator can't carry per-item tag attributes, the transport's UI display name now comes from that method instead of the `integrationAlias` tag argument.

This updates the developer docs so a plugin author building a custom SMS transport sees the current contract: the interface list and `HelloWorldTransport` example now include `getIntegrationAlias()`, the "Registering the transport" section drops the removed compiler pass and the `integrationAlias` tag argument in favor of a bare tag plus the method, and the `mautic.sms_transport` row in the service-tags reference reflects that it takes no tag arguments.

Files touched: `docs/plugin_extensions/sms.rst`, `docs/plugins/config.rst`

**Trigger Events**
- [mautic/mautic#17154: refactor(sms): replace SmsTransportPass with AutowireIterator](https://github.com/mautic/mautic/pull/17154)
