### PR TITLE
chore(deps): bump linkify-it-py from 2.1.0 to 2.1.1 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ sphinx_rtd_theme==3.1.0
 readthedocs-sphinx-search==0.3.2
 rstcheck==6.3.0
 myst-parser==5.1.0
-linkify-it-py==2.1.0
+linkify-it-py==2.1.1
 esbonio==2.1.0
 attrs==26.1.0
 sphinxcontrib-phpdomain==0.15.2


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/455f5d82-0e7e-4e3a-af65-1e8d456c07df)

Bumps `linkify-it-py` from 2.1.0 to 2.1.1 in `docs/requirements.txt` on the `7.2` branch. This is a security release that fixes quadratic complexity in `LinkifyIt.match()` on untrusted input ([GHSA-8m2q-wq3r-6hq8](https://github.com/tsutsu3/linkify-it-py/security/advisories/GHSA-8m2q-wq3r-6hq8); upstream CVE-2026-48801, CVE-2026-59887; affected versions <= 2.1.0). Mirrors the same dependency bump already raised for the `7.1` branch in PR #635, replicated here so every maintained version branch receives the security fix.

**Trigger Events**
- [Comment on developer-documentation-new PR #635: @adiati98 requesting the linkify-it-py bump be synced to the other version branches](https://github.com/mautic/developer-documentation-new/pull/635#issuecomment-5477737410)