### PR TITLE
Document new priority key for plugin route definitions

### DIFF
--- a/docs/plugins/config.rst
+++ b/docs/plugins/config.rst
@@ -136,7 +136,7 @@ Each firewall accepts an array of defined routes. Each key, the route's name, mu
 
 .. warning:: Each route's name must be unique across all bundles and firewalls and paths must be unique within the same firewall.
 
-.. warning:: Order of routes matters as Symfony uses the first route that matches the URL.
+.. warning:: Order of routes matters as Symfony uses the first route that matches the URL. Set a route's ``priority`` to control this order.
 
 Route definitions
 =================
@@ -179,6 +179,10 @@ Route definitions define the route's method, path, controller, parameters, and o
       - no
       - boolean
       - If the firewall is ``api``, setting this to ``TRUE`` automatically registers GET, POST, PUT, PATCH, and DELETE API endpoints for single and batch handling of entities.
+    * - ``priority``
+      - no
+      - integer
+      - Sets the order in which Mautic registers the route, relative to other routes. Symfony matches higher-priority routes first, and routes with equal priority keep their definition order. Use this to resolve match-order conflicts between overlapping paths. Defaults to ``0`` when omitted.
 
 Special routing parameters
 --------------------------


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/f6be125e-becf-47ac-81b4-6ee8d9282cde)

Config-declared routes can now set an optional integer `priority` key that controls the order in which Mautic registers a route, so plugin authors can resolve match-order conflicts between overlapping paths explicitly instead of relying on definition order. Symfony matches higher-priority routes first, routes with equal priority keep their definition order, and priority defaults to `0` when omitted, so existing plugin route configs are unaffected.

This documents the key in the "Route definitions" reference table on the plugin Config file page and points the existing route-order caveat to it. It does not change the plugin routing config mechanism, which remains fully supported.

**Trigger Events**
- [mautic/mautic PR #17169: move config "routes" to native Symfony #[Route] attributes](https://github.com/mautic/mautic/pull/17169)
