### PR TITLE
Fix broken Symfony event subscribers link on branch 7.1

### DIFF
--- a/docs/links/symfony_docs_event_subscribers.py
+++ b/docs/links/symfony_docs_event_subscribers.py
@@ -2,7 +2,7 @@ from . import link
 
 link_name = "Symfony event subscribers"
 link_text = "event subscribers"
-link_url = "https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers"
+link_url = "https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber"
 
 link.xref_links.update({link_name: (link_text, link_url)})
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/dd40270c-8dda-4ccd-ba68-a63f0762c3a3)

Ports the broken-link fix from PR #624 (branch 7.2) to branch 7.1, as requested by maintainer @adiati98. The "event subscribers" cross-reference on the Plugin event listeners page pointed to a Symfony docs anchor that no longer exists — Symfony moved the event dispatcher page out of `/components/` and renamed the section anchor — so the old `#using-event-subscribers` anchor returned "Anchor not found" and failed the docs linkcheck build. The xref now points to the current Symfony page and anchor. Visible link text is unchanged.

**Trigger Events**
- [Comment on developer-documentation-new PR #635 requesting the 7.1 cherry-pick](https://github.com/mautic/developer-documentation-new/pull/635#issuecomment-5493031763)