### PR TITLE
Fix broken Symfony event subscribers link on branch 7.0

### DIFF
--- a/docs/links/symfony_docs_event_subscribers.py
+++ b/docs/links/symfony_docs_event_subscribers.py
@@ -2,7 +2,7 @@ from . import link
 
 link_name = "Symfony event subscribers"
 link_text = "event subscribers"
-link_url = "https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers"
+link_url = "https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber"
 
 link.xref_links.update({link_name: (link_text, link_url)})
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/4c4c2cbd-32f0-4fde-9722-885ea4931b63)

Ports the broken-link fix from PR #624 (branch 7.2) and #654 (branch 7.1) to branch 7.0, as requested by maintainer @adiati98. The "event subscribers" cross-reference on the Plugin event listeners page pointed to a Symfony docs anchor that no longer exists — Symfony moved the event dispatcher page out of `/components/` and renamed the section anchor — so the old `#using-event-subscribers` anchor returned "Anchor not found" and failed the docs linkcheck build on this branch. The xref now points to the current Symfony page and anchor. Visible link text is unchanged.

**Trigger Events**
- [Maintainer comment on developer-documentation-new PR #654: cherry-pick the broken-link fix to other branches](https://github.com/mautic/developer-documentation-new/pull/654#issuecomment-5493181513)