### PR TITLE
Document custom search commands extension for the Email list

### DIFF
--- a/docs/plugin_extensions/emails.rst
+++ b/docs/plugin_extensions/emails.rst
@@ -5,6 +5,7 @@ There are multiple ways to extend the way Mautic works with Emails. This documen
 
 * Email tokens
 * Email settings
+* Custom search commands
 * A/B testing
 * Monitored inbox Integration
 * Email transport or Email providers
@@ -288,6 +289,122 @@ Deprecated methods
             $event->addTokens($tokens);
         }
     }
+
+Custom search commands
+**********************
+
+A custom search command is a ``command:value`` search-bar filter that a User types into the Email list's search box, alongside built-in search commands such as ``is:published``. A Plugin registers its own search command by listening to three events that CoreBundle dispatches:
+
+* ``SearchCommandEvent`` registers the command.
+* ``SearchQueryEvent`` builds the WHERE clause that filters the Email list.
+* ``SearchHelpEvent`` supplies the help text Mautic shows for the Email list's search commands.
+
+Mautic wires this mechanism only for the Email list - the context ``'email'`` - and no custom search command ships by default.
+
+.. vale off
+
+A Plugin registers these listeners the same way as any Symfony event subscriber. The complete, ready-to-copy pattern is the **Example** subsection below, which registers all three events in one subscriber. Use it as the reference. For supplementary background on event listeners and subscribers, see the :doc:`listeners and subscribers</plugins/event_listeners>` section.
+
+.. vale on
+
+.. note::
+
+   All three events share ``SearchEventTrait`` and CoreBundle dispatches them, so every listener must call ``$event->checkContext('email')`` and return early otherwise. Without this guard a listener would act outside the Email list. ``getContext()`` reads the current context, and ``checkContext(string): bool`` compares it against the context you pass.
+
+Register the command with SearchCommandEvent
+============================================
+
+``SearchCommandEvent`` makes the Email list recognize your command as a valid search command and suggest it in the search box as the User types. Your listener calls ``addCommand()`` to add a single command string, and can read or replace the whole list with ``getCommands()`` and ``setCommands(array)``. ``EmailRepository::getSearchCommands()`` dispatches this event.
+
+.. vale off
+
+Build the WHERE clause with SearchQueryEvent
+============================================
+
+.. vale on
+
+``SearchQueryEvent`` carries the active filter and the query it's assembling. Your listener reads ``$event->getFilter()`` and compares ``$filter->command`` to the command string it registered with ``addCommand()``. When they match, it calls ``$event->setExpr(...)`` and ``$event->setParameters([...])`` to contribute the WHERE clause. Build the expression from ``$event->getQuery()`` and the entity alias from ``$event->getAlias()``. ``EmailRepository::addSearchCommandWhereClause()`` dispatches this event while it resolves a search command to its WHERE clause.
+
+.. note::
+
+   ``getQuery()`` may return either an ORM ``QueryBuilder`` or a DBAL ``QueryBuilder``, so your listener must not assume one or the other.
+
+   Mautic resolves its standard search commands first, then dispatches ``SearchQueryEvent`` for Plugin listeners, and only then falls back to its built-in Email command switch. So a listener-supplied expression takes precedence over the built-in Email commands: once a listener sets an expression, ``EmailRepository`` returns it and short-circuits that switch.
+
+Document the command with SearchHelpEvent
+=========================================
+
+``SearchHelpEvent`` overrides the help text Mautic shows for the Email list's search commands. Your listener calls ``setHelp()`` to replace the default translation key ``mautic.email.help.searchcommands`` with its own key, so your custom command appears in that help text. ``getHelp()`` reads the current key. ``EmailController`` dispatches this event when it renders the Email list. Define the key you pass to ``setHelp()`` in your Plugin's own translation files. The Example below uses ``'mautic.helloworld.email.help.searchcommands'``. Otherwise Mautic shows the raw key instead of the help text.
+
+Example
+=======
+
+The subscriber below registers an ``is:special`` command on the Email list and filters the list to Emails whose ``customHtml`` contains ``FINDME``. Once you enable the Plugin, type ``is:special`` into the Email list search box to see it in action.
+
+.. code-block:: PHP
+
+    <?php
+    // plugins/HelloWorldBundle/EventListener/EmailSearchCommandSubscriber.php
+
+    declare(strict_types=1);
+
+    namespace MauticPlugin\HelloWorldBundle\EventListener;
+
+    use Mautic\CoreBundle\Event\SearchCommandEvent;
+    use Mautic\CoreBundle\Event\SearchHelpEvent;
+    use Mautic\CoreBundle\Event\SearchQueryEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    final class EmailSearchCommandSubscriber implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                SearchCommandEvent::class => ['onSearchCommand', 0],
+                SearchQueryEvent::class   => ['onSearchQuery', 0],
+                SearchHelpEvent::class    => ['onSearchHelp', 0],
+            ];
+        }
+
+        public function onSearchCommand(SearchCommandEvent $event): void
+        {
+            if (!$event->checkContext('email')) {
+                return;
+            }
+
+            $event->addCommand('is:special');
+        }
+
+        public function onSearchQuery(SearchQueryEvent $event): void
+        {
+            if (!$event->checkContext('email')) {
+                return;
+            }
+
+            $filter = $event->getFilter();
+
+            if ('is:special' !== $filter->command) {
+                return;
+            }
+
+            $q     = $event->getQuery();
+            $alias = $event->getAlias();
+
+            $event->setExpr($q->expr()->like($alias.'.customHtml', ':specialMarker'));
+            $event->setParameters(['specialMarker' => '%FINDME%']);
+        }
+
+        public function onSearchHelp(SearchHelpEvent $event): void
+        {
+            if (!$event->checkContext('email')) {
+                return;
+            }
+
+            $event->setHelp('mautic.helloworld.email.help.searchcommands');
+        }
+    }
+
+The :doc:`Quick filters for searches</design/quick_filters>` page covers a complementary task: surfacing existing search commands as clickable quick-filter buttons. This section covers registering new commands instead. The two features compose, so you can register a command here and then optionally surface it as a quick-filter button using that page.
 
 .. vale off
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/07862351-6489-4cc0-af8b-2b13f04ca4fb)

Mautic 7.x adds three CoreBundle events — `SearchCommandEvent`, `SearchQueryEvent`, and `SearchHelpEvent` — that let a Plugin register a custom `command:value` search-bar filter on the Email list, supply the WHERE clause that filters the list, and override the help text shown for its search commands. This adds a "Custom search commands" section to the Email plugin-extensions page documenting the three-event contract, the required `checkContext('email')` guard, the resolution order relative to built-in commands, and a complete, ready-to-copy `EventSubscriber` example.

**Trigger Events**
- [GitHub PR mautic/mautic#17281: Add custom search command](https://github.com/mautic/mautic/pull/17281)
