### PR TITLE
Document continueSending API field and FilterEvent removal reasons

### DIFF
--- a/docs/plugin_extensions/sms.rst
+++ b/docs/plugin_extensions/sms.rst
@@ -198,12 +198,17 @@ Generic filter
 
 Use ``SmsEvents::FILTER_CONTACTS_ON_SEND`` for any remaining filtering logic, such as removing Contacts without phone numbers. Its listener receives a ``FilterEvent``.
 
-All three event classes share a common API, shown here for :xref:`FilterEvent source`:
+The methods below describe ``FilterEvent``, whose signatures come from :xref:`FilterEvent source`. The optional ``reason`` parameters and the ``REMOVAL_REASON_MISSING_NUMBER`` constant are specific to ``FilterEvent``.
 
-* ``getContacts()`` - Returns the array of Contacts
-* ``removeContact(int $id)`` - Remove a single Contact by ID
-* ``removeContacts(array $contacts)`` - Remove multiple Contacts
-* ``getRemovedContacts()`` - Get the list of removed Contacts
+* ``getContacts()`` - Returns the array of Contacts.
+* ``removeContact(int $id, ?string $reason = null)`` - Remove a single Contact by ID. The ``reason`` is optional.
+* ``removeContacts(array $contacts, ?string $reason = null)`` - Remove multiple Contacts. The ``reason`` is optional.
+* ``getRemovedContacts(?string $reason = null)`` - Get the list of removed Contacts. Optionally pass a reason to return only the Contacts removed for that reason.
+* ``FilterEvent::REMOVAL_REASON_MISSING_NUMBER`` - the reason value Mautic core records when it removes a Contact that has no phone number.
+
+The ``reason`` parameters are optional, so existing subscribers stay backward compatible.
+
+``getContacts()`` is common to all three events. ``DncEvent`` also exposes ``removeContact()``, ``removeContacts()``, and ``getRemovedContacts()``, but its ``removeContact()`` and ``removeContacts()`` take no ``reason`` parameter. ``QueueEvent`` instead exposes ``queueContact(int $id)``, ``queueContacts(array $contacts)``, and ``getQueuedContacts()``.
 
 Campaign SMS events
 *******************

--- a/docs/rest_api/text_messages.rst
+++ b/docs/rest_api/text_messages.rst
@@ -44,6 +44,9 @@ Use these properties when creating a Text Message in a ``POST`` request. These p
    * - ``publishDown``
      - datetime/null
      - Date/time the SMS gets unpublished
+   * - ``continueSending``
+     - boolean
+     - Whether a scheduled Segment SMS - one with type ``list`` - keeps sending or sends once, defaulting to one-time when omitted. ``false`` sends once and ignores ``publishDown``, while ``true`` keeps sending with an optional later ``publishDown`` stop time.
    * - ``dateAdded``
      - ``datetime``
      - Date/time SMS got created
@@ -68,6 +71,12 @@ Use these properties when creating a Text Message in a ``POST`` request. These p
    * - ``sentCount``
      - int
      - How many times the SMS got sent
+
+.. note::
+
+   Writing or changing any schedule field - ``isPublished``, ``publishUp``, ``publishDown``, or ``continueSending`` - requires the ``sms:smses:publishown`` or ``sms:smses:publishother`` permission. Without it, Mautic ignores these fields on write.
+
+   ``publishDown`` reads back as ``null`` for a one-time ``list`` SMS - one sent with ``continueSending`` set to false.
 
 **Using Mautic's API Library**
 
@@ -305,6 +314,9 @@ To edit an SMS and create a new one if the SMS isn't found:
    * - ``publishDown``
      - datetime/null
      - Date/time the SMS should gets unpublished
+   * - ``continueSending``
+     - boolean
+     - Whether a scheduled Segment SMS - one with type ``list`` - keeps sending or sends once, defaulting to one-time when omitted. ``false`` sends once and ignores ``publishDown``, while ``true`` keeps sending with an optional later ``publishDown`` stop time.
    * - ``language``
      - string
      - Language locale of the SMS


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/80e3fad7-618b-464e-8890-dd5ad9da1221)

Mautic 7.x adds a Schedule Send workflow for Segment Text Messages, which exposes a developer surface. This documents the new continueSending boolean on the Text Messages REST API (in the properties and PUT/PATCH parameter tables), with a note that writing any schedule field requires publish permission and that publishDown reads back as null for a one-time list SMS. It also documents the optional reason parameter added to FilterEvent's removeContact/removeContacts/getRemovedContacts and the FilterEvent::REMOVAL_REASON_MISSING_NUMBER constant in the SMS extension guide, scoping the reason API to FilterEvent (DncEvent and QueueEvent are unaffected).

Documents mautic/mautic#17310.

**Trigger Events**
- [Message in Slack channel #docs-notifications: maintainer confirmed docs branch 7.3 now exists](https://mautic.slack.com/archives/C0114H9GRH8/p1788961412506879)
