### PR TITLE
Document the themeable email-validation.html.twig template (8.0)

### DIFF
--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -114,6 +114,12 @@ Twig files
 
 This file is mainly used as the Landing Page for when a Contact unsubscribes or resubscribes to the system's Emails. Other areas use this so all Themes should include it.
 
+.. vale off
+
+In the unsubscribe and resubscribe flow, the email address validation step now precedes this page. See :ref:`themes/getting_started:html/email-validation.html.twig`.
+
+.. vale on
+
 It requires echoing two variables: ``message`` and ``content``.
 
 ``message`` contains the string message such as "You have been unsubscribed."
@@ -137,6 +143,45 @@ It requires echoing two variables: ``message`` and ``content``.
             </div>
         </body>
     </html>
+
+``html/email-validation.html.twig``
+-----------------------------------
+
+Mautic uses this template to render the validation screen that recipients see before they unsubscribe or resubscribe.
+
+Unlike the ``email``, ``form``, and ``page`` feature files, this template is optional. It isn't a required feature file and doesn't go in the ``features`` array. If a Theme doesn't provide it, Mautic renders the core template. A Theme only adds it to customize the validation screen's appearance.
+
+The template extends the core template ``@MauticCore/Theme/email-validation.html.twig``, which in turn extends ``message.html.twig`` through the ``message_content`` block.
+
+A Theme can override the following Twig blocks:
+
+* ``message_content`` - the outer content region. The core validation template overrides this block from ``message.html.twig`` to inject the validation screen.
+* ``validation_content`` - the validation card holding the heading, the instructional message, and the confirmation Form.
+* ``validation_error`` - the alert region shown when the submitted address doesn't match the one Mautic generated the link for.
+* ``validation_enhancements`` - the screen's styling and the progressive-enhancement script, for example the submit button's loading state.
+
+Mautic resolves the template in the following order:
+
+#. ``html/email-validation.html.twig`` in the Theme selected for the Email.
+#. The Theme configured as the site's default in system settings.
+#. All installed Themes.
+
+The blank Theme ships an example override you can copy as a starting point. Override any of the preceding blocks, or the ``content`` block it inherits from ``message.html.twig``, to customize the validation screen:
+
+.. code-block:: twig
+
+    {% extends '@MauticCore/Theme/email-validation.html.twig' %}
+
+    {#
+     This file intentionally only extends the core template.
+     It exists as an example entry point for theme-level customization.
+
+     Example usage:
+
+     {% block content %}
+    	 {{ parent() }}
+     {% endblock %}
+    #}
 
 ``html/email.html.twig``
 ------------------------

--- a/docs/themes/getting_started.rst
+++ b/docs/themes/getting_started.rst
@@ -116,7 +116,7 @@ This file is mainly used as the Landing Page for when a Contact unsubscribes or 
 
 .. vale off
 
-In the unsubscribe and resubscribe flow, the email address validation step now precedes this page. See :ref:`themes/getting_started:html/email-validation.html.twig`.
+In the unsubscribe and resubscribe flow, the email address validation step now precedes this page. See :ref:`html/email-validation.html.twig <email-validation Twig file>`.
 
 .. vale on
 
@@ -143,6 +143,8 @@ It requires echoing two variables: ``message`` and ``content``.
             </div>
         </body>
     </html>
+
+.. _email-validation Twig file:
 
 ``html/email-validation.html.twig``
 -----------------------------------


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/4b8aa364-0258-4bcd-92e7-dc3d91e448b4)

Ports the maintainer-approved changes from #613 onto the 8.0 branch, at @adiati98's request.

Mautic 7.x adds an email address validation step to the unsubscribe and resubscribe flow (mautic/mautic#16870), rendered by the new core template `@MauticCore/Theme/email-validation.html.twig`, and theme developers can override its appearance.

This adds an `html/email-validation.html.twig` subsection to the theme structure guide (`docs/themes/getting_started.rst`) documenting: that the template is optional (not a required feature file), that it extends `message.html.twig` through the `message_content` block, the four overridable Twig blocks (`message_content`, `validation_content`, `validation_error`, `validation_enhancements`), the theme resolution order Mautic uses to find it, and the blank Theme's example override as a starting point. It also cross-references the new template from the `html/message.html.twig` entry.

The diff is identical to #613 (a clean addition to a single file). The 8.0 and 7.3 branches currently point to the same commit and the target file is byte-identical on both, so the change applies cleanly. Vale is clean on the added lines.

**Review feedback applied** (@adiati98: "please apply the changes as well to #666")
- Ported #613's approved cross-reference fix: switched the `:ref:` in the `html/message.html.twig` section from the autosection form to the explicit-label form `` :ref:`html/email-validation.html.twig <email-validation Twig file>` `` and added the matching `.. _email-validation Twig file:` anchor before the section heading. Applied verbatim. With this, #666's changed content is now byte-identical to #613's approved state.

**Trigger Events**
- [mautic/mautic#16870: Making unsubscribes/resubscribes more secure](https://github.com/mautic/mautic/pull/16870)