### PR TITLE
Update ClassMetadataBuilder association-builder return types for Doctrine ORM 3

### DIFF
--- a/docs/plugins/database.rst
+++ b/docs/plugins/database.rst
@@ -148,12 +148,12 @@ You can build the schema through Doctrine's ``Doctrine\ORM\Mapping\Builder\Class
 
     .. php:method:: createManyToMany(string $name, string $targetEntity)
 
-        Creates a many to many field to the targeted entity. Instantiates and returns a ``Mautic\CoreBundle\Doctrine\Mapping\ManyToManyAssociationBuilder`` object that decorates ``Doctrine\ORM\Mapping\Builder\ManyToManyAssociationBuilder`` with ``orphanRemoval()`` support.
+        Creates a many to many field to the targeted entity. Instantiates and returns a ``Doctrine\ORM\Mapping\Builder\ManyToManyAssociationBuilder`` object, Doctrine's own builder, which supports ``orphanRemoval()`` natively.
 
         :param string $name: Name of the ORM field.
         :param string $targetEntity: Fully qualified classname for the targeted entity.
 
-        :returns: \\Mautic\\CoreBundle\\Doctrine\\Mapping\\ManyToManyAssociationBuilder
+        :returns: \\Doctrine\\ORM\\Mapping\\Builder\\ManyToManyAssociationBuilder
 
     .. php:method:: createManyToOne(string $name, string $targetEntity)
 
@@ -166,12 +166,12 @@ You can build the schema through Doctrine's ``Doctrine\ORM\Mapping\Builder\Class
 
     .. php:method:: createOneToMany(string $name, string $targetEntity)
 
-        Creates a field with a one to many relationship to the targeted entity. Instantiates and returns a ``Mautic\CoreBundle\Doctrine\Mapping\OneToManyAssociationBuilder`` object that decorates ``Doctrine\ORM\Mapping\Builder\OneToManyAssociationBuilder`` with ``orphanRemoval()`` support.
+        Creates a field with a one to many relationship to the targeted entity. Instantiates and returns a ``Doctrine\ORM\Mapping\Builder\OneToManyAssociationBuilder`` object, Doctrine's own builder, which supports ``orphanRemoval()`` natively.
 
         :param string $name: Name of the ORM field.
         :param string $targetEntity: Fully qualified classname for the targeted entity.
 
-        :returns: \\Mautic\\CoreBundle\\Doctrine\\Mapping\\OneToManyAssociationBuilder
+        :returns: \\Doctrine\\ORM\\Mapping\\Builder\\OneToManyAssociationBuilder
 
     .. php:method:: createOneToOne(string $name, string $targetEntity)
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/f4636ec1-6b9a-4bcc-a7ed-c9ef3578446c)

Mautic 8's upgrade to Doctrine ORM 3 and DBAL 4 (mautic/mautic#17361) removes Mautic's `ManyToManyAssociationBuilder` and `OneToManyAssociationBuilder` decorator classes and drops the matching `ClassMetadataBuilder` overrides. As a result, `createManyToMany()` and `createOneToMany()` now instantiate and return Doctrine's own builder classes (`Doctrine\ORM\Mapping\Builder\ManyToManyAssociationBuilder` and `OneToManyAssociationBuilder`), which support `orphanRemoval()` natively.

This corrects the two documented return types in the Entities and schema page so plugin developers building schema through `ClassMetadataBuilder` see the classes their code actually receives on Mautic 8. `createManyToOne()`/`createOneToOne()` still return Mautic's `AssociationBuilder`, which the upgrade retains, and are left unchanged.

**Trigger Events**
- [GitHub PR mautic/mautic#17361: Upgrade to Doctrine ORM 3 and DBAL 4](https://github.com/mautic/mautic/pull/17361)
